### PR TITLE
Fix library reference in doc 

### DIFF
--- a/cognite/pygen/dm_clients/README.md
+++ b/cognite/pygen/dm_clients/README.md
@@ -58,7 +58,7 @@ With the (future) arrival of GraphQL mutations in DM, this package might become 
 
 ## Installation
 
-1. `pip install cognite-gql-pygen`
+1. `pip install cognite-pygen`
 2. Create a `settings.toml` file, see [settings.toml](./settings.toml) for a template.
    * this step is optional, all settings can be specified in code or via env variables
    * `settings.toml` should contain only things which are safe to commit to git


### PR DESCRIPTION
Fix library name

## Description
It seems the library name has changed from cognite-gql-pygen to cognite-pygen.
This PR changes the README  to reflect that.

## Checklist:
- [ ] Tests added/updated.
- [x] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
