### PR TITLE
ci: only run unit tests upon release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pre-commit/action@v2.0.0
 
-  tests:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,9 +30,7 @@ jobs:
           poetry install -E all
 
       - name: Test
-        env:
-          CI: 1
-        run: pytest
+        run: pytest cognite tests/test_unit
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
