### PR TITLE
[PYG-59] Default clean in generate notebook

### DIFF
--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import shutil
 import sys
 import tempfile
 from collections.abc import Sequence
@@ -136,6 +137,7 @@ def generate_sdk_notebook(
     client_name: Optional[str] = None,
     default_instance_space: str | None = None,
     config: Optional[PygenConfig] = None,
+    clean_pygen_temp_dir: bool = True,
 ) -> Any:
     """
     Generates a Python SDK tailored to the given Data Model(s) and imports it into the current Python session.
@@ -163,11 +165,19 @@ def generate_sdk_notebook(
         default_instance_space: The default instance space to use for the generated SDK. Defaults to the
             instance space of the first data model given.
         config: The configuration used to control how to generate the SDK.
+        clean_pygen_temp_dir: Whether to clean the temporary directory used to store the generated SDK.
+            Defaults to True.
 
     Returns:
         The instantiated generated client class.
     """
     output_dir = Path(tempfile.gettempdir()) / "pygen"
+    if clean_pygen_temp_dir and output_dir.exists():
+        try:
+            shutil.rmtree(output_dir)
+        except Exception as e:
+            print(f"Failed to clean temporary directory {output_dir}: {e}")
+
     data_model = _get_data_model(model_id, client, print)
     external_id = _extract_external_id(data_model)
     if top_level_package is None:

--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -177,6 +177,8 @@ def generate_sdk_notebook(
             shutil.rmtree(output_dir)
         except Exception as e:
             print(f"Failed to clean temporary directory {output_dir}: {e}")
+        else:
+            print(f"Cleaned temporary directory {output_dir}")
 
     data_model = _get_data_model(model_id, client, print)
     external_id = _extract_external_id(data_model)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
-## [0.TBD] - TBD-01-24
+## [0.34.0] - TBD-01-24
 ### Added
 * Option for returning generated SDK as a `dict[Path, str]` instead of writing to disk when calling `generate_sdk`.
 * Option for cleaning the `pygen` temporary directly when calling `generate_sdk_notebook`. This is useful to ensure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ Changes are grouped as follows
 ## [0.TBD] - TBD-01-24
 ### Added
 * Option for returning generated SDK as a `dict[Path, str]` instead of writing to disk when calling `generate_sdk`.
+* Option for cleaning the `pygen` temporary directly when calling `generate_sdk_notebook`. This is useful to ensure
+  that previous generated SDKs are not interfering with the current SDK by accident.
 ### Fixed
 * `pygen` now handles views with the same `external_id` in different spaces and versions. Note that this can only occur if
   `pygen` is used with multiple data models.


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
- [ ] Regenerate example SDK `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
