### PR TITLE
[PYG-35] tests: run test in cicd

### DIFF
--- a/tests/test_unit/test_generator/test_generate_api_client.py
+++ b/tests/test_unit/test_generator/test_generate_api_client.py
@@ -1,16 +1,10 @@
-import platform
-
-import pytest
+import difflib
 
 from cognite.pygen._core.generators import SDKGenerator
 from cognite.pygen._generator import CodeFormatter
 from tests.constants import OMNI_MULTI_SDK, OmniMultiFiles
 
 
-@pytest.mark.skipif(
-    not platform.platform().startswith("Windows"),
-    reason="There is currently some strange problem with the diff on non-windows",
-)
 def test_generate_api_client(code_formatter: CodeFormatter):
     # Arrange
     sdk_generator = SDKGenerator(
@@ -25,4 +19,4 @@ def test_generate_api_client(code_formatter: CodeFormatter):
     actual = code_formatter.format_code(actual)
 
     # Assert
-    assert actual == expected
+    assert actual == expected, "\n".join(difflib.unified_diff(expected.splitlines(), actual.splitlines()))

--- a/tests/test_unit/test_generator/test_generate_core.py
+++ b/tests/test_unit/test_generator/test_generate_core.py
@@ -1,6 +1,4 @@
-import platform
-
-import pytest
+import difflib
 
 from cognite.pygen._core.generators import MultiAPIGenerator, SDKGenerator
 from cognite.pygen._generator import CodeFormatter
@@ -41,10 +39,7 @@ def test_generate_data_class_init_file(omni_multi_api_generator: MultiAPIGenerat
     assert actual == expected
 
 
-@pytest.mark.skipif(
-    not platform.platform().startswith("Windows"),
-    reason="There is currently some strange problem with the diff on non-windows",
-)
+# @pytest.mark.skipif(
 def test_create_api_client(omni_sdk_generator: SDKGenerator, code_formatter: CodeFormatter):
     # Arrange
     expected = OmniFiles.client.read_text()
@@ -54,4 +49,4 @@ def test_create_api_client(omni_sdk_generator: SDKGenerator, code_formatter: Cod
     actual = code_formatter.format_code(actual)
 
     # Assert
-    assert actual == expected
+    assert actual == expected, "\n".join(difflib.unified_diff(expected.splitlines(), actual.splitlines()))

--- a/tests/test_unit/test_generator/test_generate_core.py
+++ b/tests/test_unit/test_generator/test_generate_core.py
@@ -39,7 +39,6 @@ def test_generate_data_class_init_file(omni_multi_api_generator: MultiAPIGenerat
     assert actual == expected
 
 
-# @pytest.mark.skipif(
 def test_create_api_client(omni_sdk_generator: SDKGenerator, code_formatter: CodeFormatter):
     # Arrange
     expected = OmniFiles.client.read_text()

--- a/tests/test_unit/test_generator/test_sdk_generator_equipment_unit_sdk.py
+++ b/tests/test_unit/test_generator/test_sdk_generator_equipment_unit_sdk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import platform
+import difflib
 
 import pytest
 from cognite.client import data_modeling as dm
@@ -187,10 +187,6 @@ def test_generate_data_class_init_file(multi_api_generator: MultiAPIGenerator, c
     assert actual == expected
 
 
-@pytest.mark.skipif(
-    not platform.platform().startswith("Windows"),
-    reason="There is currently some strange problem with the diff on non-windows",
-)
 def test_create_api_client(sdk_generator: SDKGenerator, code_formatter: CodeFormatter):
     # Arrange
     expected = EquipmentSDKFiles.client.read_text()
@@ -200,4 +196,4 @@ def test_create_api_client(sdk_generator: SDKGenerator, code_formatter: CodeForm
     actual = code_formatter.format_code(actual)
 
     # Assert
-    assert actual == expected
+    assert actual == expected, "\n".join(difflib.unified_diff(expected.splitlines(), actual.splitlines()))


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
- [ ] Regenerate example SDK `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
