### PR TITLE
refator; regen v1 SDSs

### DIFF
--- a/examples-pydantic-v1/equipment_unit_pydantic_v1/client/_api/_core.py
+++ b/examples-pydantic-v1/equipment_unit_pydantic_v1/client/_api/_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
+from itertools import groupby
 
 from collections import Counter, defaultdict, UserList
 from collections.abc import Sequence, Collection
@@ -101,8 +102,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str,
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | None: ...
 
@@ -112,8 +113,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModelList: ...
 
@@ -122,8 +123,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str | SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | T_DomainModelList | None:
         is_multiple = True
@@ -137,7 +138,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         nodes = self._class_list([self._class_type.from_instance(node) for node in instances.nodes])
 
         if retrieve_edges and nodes:
-            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_view_id_penta)
 
         if is_multiple:
             return nodes
@@ -304,7 +305,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         limit: int,
         filter: dm.Filter,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
+        edge_api_name_type_direction_view_id_penta: (
             list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
         ) = None,
     ) -> T_DomainModelList:
@@ -313,32 +314,62 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         )
         node_list = self._class_list([self._class_type.from_instance(node) for node in nodes])
         if retrieve_edges and node_list:
-            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_view_id_penta)
 
         return node_list
 
-    @classmethod
     def _retrieve_and_set_edge_types(
-        cls,
+        self,
         nodes: T_DomainModelList,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ):
-        for edge_api, edge_name, edge_type, direction in edge_api_name_type_direction_quad or []:
-            is_type = dm.filters.Equals(
-                ["edge", "type"],
-                {"space": edge_type.space, "externalId": edge_type.external_id},
-            )
-            if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
-                edges = edge_api._list(limit=-1, filter_=is_type)
-            else:
-                is_nodes = dm.filters.In(
-                    ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
-                    values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+        for edge_type, values in groupby(edge_api_name_type_direction_view_id_penta or [], lambda x: x[2].as_tuple()):
+            edges: dict[dm.EdgeId, dm.Edge] = {}
+            value_list = list(values)
+            for edge_api, edge_name, edge_type, direction, view_id in value_list:
+                is_type = dm.filters.Equals(
+                    ["edge", "type"],
+                    {"space": edge_type.space, "externalId": edge_type.external_id},
                 )
-                edges = edge_api._list(limit=-1, filter_=dm.filters.And(is_type, is_nodes))
-            cls._set_edges(nodes, edges, edge_name, direction)
+                if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
+                    filter_ = is_type
+                else:
+                    is_nodes = dm.filters.In(
+                        ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
+                        values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+                    )
+                    filter_ = dm.filters.And(is_type, is_nodes)
+                result = edge_api._list(limit=-1, filter_=filter_)
+                edges.update({edge.as_id(): edge for edge in result})
+            edge_list = list(edges.values())
+            if len(value_list) == 1:
+                _, edge_name, _, direction, _ = value_list[0]
+                self._set_edges(nodes, edge_list, edge_name, direction)
+            else:
+                # This is an 'edge' case where we have view with multiple edges of the same type.
+                edge_by_end_node: dict[tuple[str, str], list[dm.Edge]] = defaultdict(list)
+                for edge in edge_list:
+                    node_id = edge.end_node.as_tuple() if direction == "outwards" else edge.start_node.as_tuple()
+                    edge_by_end_node[node_id].append(edge)
+
+                for no, (edge_api, edge_name, _, direction, view_id) in enumerate(value_list):
+                    if not edge_by_end_node:
+                        break
+                    if no == len(value_list) - 1:
+                        # Last edge, use all remaining nodes
+                        attribute_edges = [e for e_list in edge_by_end_node.values() for e in e_list]
+                    else:
+                        existing = self._client.data_modeling.instances.retrieve(
+                            nodes=list(edge_by_end_node), sources=view_id
+                        )
+                        attribute_edges = []
+                        for node in existing.nodes:
+                            attribute_edge = edge_by_end_node.pop(node.as_id().as_tuple(), [])
+                            attribute_edges.extend(attribute_edge)
+
+                    self._set_edges(nodes, attribute_edges, edge_name, direction)
 
     @staticmethod
     def _set_edges(

--- a/examples-pydantic-v1/equipment_unit_pydantic_v1/client/_api/unit_procedure.py
+++ b/examples-pydantic-v1/equipment_unit_pydantic_v1/client/_api/unit_procedure.py
@@ -207,18 +207,20 @@ class UnitProcedureAPI(NodeAPI[UnitProcedure, UnitProcedureWrite, UnitProcedureL
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.work_orders_edge,
                     "work_orders",
                     dm.DirectRelationReference("IntegrationTestsImmutable", "UnitProcedure.work_order"),
                     "outwards",
+                    dm.ViewId("IntegrationTestsImmutable", "WorkOrder", "c5543fb2b1bc81"),
                 ),
                 (
                     self.work_units_edge,
                     "work_units",
                     dm.DirectRelationReference("IntegrationTestsImmutable", "UnitProcedure.equipment_module"),
                     "outwards",
+                    dm.ViewId("IntegrationTestsImmutable", "EquipmentModule", "b1cd4bf14a7a33"),
                 ),
             ],
         )
@@ -501,18 +503,20 @@ class UnitProcedureAPI(NodeAPI[UnitProcedure, UnitProcedureWrite, UnitProcedureL
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.work_orders_edge,
                     "work_orders",
                     dm.DirectRelationReference("IntegrationTestsImmutable", "UnitProcedure.work_order"),
                     "outwards",
+                    dm.ViewId("IntegrationTestsImmutable", "WorkOrder", "c5543fb2b1bc81"),
                 ),
                 (
                     self.work_units_edge,
                     "work_units",
                     dm.DirectRelationReference("IntegrationTestsImmutable", "UnitProcedure.equipment_module"),
                     "outwards",
+                    dm.ViewId("IntegrationTestsImmutable", "EquipmentModule", "b1cd4bf14a7a33"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/omni_multi_pydantic_v1/_api/_core.py
+++ b/examples-pydantic-v1/omni_multi_pydantic_v1/_api/_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
+from itertools import groupby
 
 from collections import Counter, defaultdict, UserList
 from collections.abc import Sequence, Collection
@@ -101,8 +102,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str,
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | None: ...
 
@@ -112,8 +113,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModelList: ...
 
@@ -122,8 +123,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str | SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | T_DomainModelList | None:
         is_multiple = True
@@ -137,7 +138,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         nodes = self._class_list([self._class_type.from_instance(node) for node in instances.nodes])
 
         if retrieve_edges and nodes:
-            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_view_id_penta)
 
         if is_multiple:
             return nodes
@@ -304,7 +305,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         limit: int,
         filter: dm.Filter,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
+        edge_api_name_type_direction_view_id_penta: (
             list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
         ) = None,
     ) -> T_DomainModelList:
@@ -313,32 +314,62 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         )
         node_list = self._class_list([self._class_type.from_instance(node) for node in nodes])
         if retrieve_edges and node_list:
-            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_view_id_penta)
 
         return node_list
 
-    @classmethod
     def _retrieve_and_set_edge_types(
-        cls,
+        self,
         nodes: T_DomainModelList,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ):
-        for edge_api, edge_name, edge_type, direction in edge_api_name_type_direction_quad or []:
-            is_type = dm.filters.Equals(
-                ["edge", "type"],
-                {"space": edge_type.space, "externalId": edge_type.external_id},
-            )
-            if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
-                edges = edge_api._list(limit=-1, filter_=is_type)
-            else:
-                is_nodes = dm.filters.In(
-                    ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
-                    values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+        for edge_type, values in groupby(edge_api_name_type_direction_view_id_penta or [], lambda x: x[2].as_tuple()):
+            edges: dict[dm.EdgeId, dm.Edge] = {}
+            value_list = list(values)
+            for edge_api, edge_name, edge_type, direction, view_id in value_list:
+                is_type = dm.filters.Equals(
+                    ["edge", "type"],
+                    {"space": edge_type.space, "externalId": edge_type.external_id},
                 )
-                edges = edge_api._list(limit=-1, filter_=dm.filters.And(is_type, is_nodes))
-            cls._set_edges(nodes, edges, edge_name, direction)
+                if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
+                    filter_ = is_type
+                else:
+                    is_nodes = dm.filters.In(
+                        ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
+                        values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+                    )
+                    filter_ = dm.filters.And(is_type, is_nodes)
+                result = edge_api._list(limit=-1, filter_=filter_)
+                edges.update({edge.as_id(): edge for edge in result})
+            edge_list = list(edges.values())
+            if len(value_list) == 1:
+                _, edge_name, _, direction, _ = value_list[0]
+                self._set_edges(nodes, edge_list, edge_name, direction)
+            else:
+                # This is an 'edge' case where we have view with multiple edges of the same type.
+                edge_by_end_node: dict[tuple[str, str], list[dm.Edge]] = defaultdict(list)
+                for edge in edge_list:
+                    node_id = edge.end_node.as_tuple() if direction == "outwards" else edge.start_node.as_tuple()
+                    edge_by_end_node[node_id].append(edge)
+
+                for no, (edge_api, edge_name, _, direction, view_id) in enumerate(value_list):
+                    if not edge_by_end_node:
+                        break
+                    if no == len(value_list) - 1:
+                        # Last edge, use all remaining nodes
+                        attribute_edges = [e for e_list in edge_by_end_node.values() for e in e_list]
+                    else:
+                        existing = self._client.data_modeling.instances.retrieve(
+                            nodes=list(edge_by_end_node), sources=view_id
+                        )
+                        attribute_edges = []
+                        for node in existing.nodes:
+                            attribute_edge = edge_by_end_node.pop(node.as_id().as_tuple(), [])
+                            attribute_edges.extend(attribute_edge)
+
+                    self._set_edges(nodes, attribute_edges, edge_name, direction)
 
     @staticmethod
     def _set_edges(

--- a/examples-pydantic-v1/omni_pydantic_v1/_api/_core.py
+++ b/examples-pydantic-v1/omni_pydantic_v1/_api/_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
+from itertools import groupby
 
 from collections import Counter, defaultdict, UserList
 from collections.abc import Sequence, Collection
@@ -101,8 +102,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str,
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | None: ...
 
@@ -112,8 +113,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModelList: ...
 
@@ -122,8 +123,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str | SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | T_DomainModelList | None:
         is_multiple = True
@@ -137,7 +138,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         nodes = self._class_list([self._class_type.from_instance(node) for node in instances.nodes])
 
         if retrieve_edges and nodes:
-            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_view_id_penta)
 
         if is_multiple:
             return nodes
@@ -304,7 +305,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         limit: int,
         filter: dm.Filter,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
+        edge_api_name_type_direction_view_id_penta: (
             list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
         ) = None,
     ) -> T_DomainModelList:
@@ -313,32 +314,62 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         )
         node_list = self._class_list([self._class_type.from_instance(node) for node in nodes])
         if retrieve_edges and node_list:
-            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_view_id_penta)
 
         return node_list
 
-    @classmethod
     def _retrieve_and_set_edge_types(
-        cls,
+        self,
         nodes: T_DomainModelList,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ):
-        for edge_api, edge_name, edge_type, direction in edge_api_name_type_direction_quad or []:
-            is_type = dm.filters.Equals(
-                ["edge", "type"],
-                {"space": edge_type.space, "externalId": edge_type.external_id},
-            )
-            if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
-                edges = edge_api._list(limit=-1, filter_=is_type)
-            else:
-                is_nodes = dm.filters.In(
-                    ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
-                    values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+        for edge_type, values in groupby(edge_api_name_type_direction_view_id_penta or [], lambda x: x[2].as_tuple()):
+            edges: dict[dm.EdgeId, dm.Edge] = {}
+            value_list = list(values)
+            for edge_api, edge_name, edge_type, direction, view_id in value_list:
+                is_type = dm.filters.Equals(
+                    ["edge", "type"],
+                    {"space": edge_type.space, "externalId": edge_type.external_id},
                 )
-                edges = edge_api._list(limit=-1, filter_=dm.filters.And(is_type, is_nodes))
-            cls._set_edges(nodes, edges, edge_name, direction)
+                if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
+                    filter_ = is_type
+                else:
+                    is_nodes = dm.filters.In(
+                        ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
+                        values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+                    )
+                    filter_ = dm.filters.And(is_type, is_nodes)
+                result = edge_api._list(limit=-1, filter_=filter_)
+                edges.update({edge.as_id(): edge for edge in result})
+            edge_list = list(edges.values())
+            if len(value_list) == 1:
+                _, edge_name, _, direction, _ = value_list[0]
+                self._set_edges(nodes, edge_list, edge_name, direction)
+            else:
+                # This is an 'edge' case where we have view with multiple edges of the same type.
+                edge_by_end_node: dict[tuple[str, str], list[dm.Edge]] = defaultdict(list)
+                for edge in edge_list:
+                    node_id = edge.end_node.as_tuple() if direction == "outwards" else edge.start_node.as_tuple()
+                    edge_by_end_node[node_id].append(edge)
+
+                for no, (edge_api, edge_name, _, direction, view_id) in enumerate(value_list):
+                    if not edge_by_end_node:
+                        break
+                    if no == len(value_list) - 1:
+                        # Last edge, use all remaining nodes
+                        attribute_edges = [e for e_list in edge_by_end_node.values() for e in e_list]
+                    else:
+                        existing = self._client.data_modeling.instances.retrieve(
+                            nodes=list(edge_by_end_node), sources=view_id
+                        )
+                        attribute_edges = []
+                        for node in existing.nodes:
+                            attribute_edge = edge_by_end_node.pop(node.as_id().as_tuple(), [])
+                            attribute_edges.extend(attribute_edge)
+
+                    self._set_edges(nodes, attribute_edges, edge_name, direction)
 
     @staticmethod
     def _set_edges(

--- a/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_a.py
+++ b/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_a.py
@@ -200,12 +200,13 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.outwards_edge,
                     "outwards",
                     dm.DirectRelationReference("pygen-models", "bidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )
@@ -488,12 +489,13 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.outwards_edge,
                     "outwards",
                     dm.DirectRelationReference("pygen-models", "bidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_b.py
+++ b/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_b.py
@@ -196,18 +196,20 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.inwards_edge,
                     "inwards",
                     dm.DirectRelationReference("pygen-models", "bidirectional"),
                     "inwards",
+                    dm.ViewId("pygen-models", "ConnectionItemA", "1"),
                 ),
                 (
                     self.self_edge_edge,
                     "self_edge",
                     dm.DirectRelationReference("pygen-models", "reflexive"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )
@@ -462,18 +464,20 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.inwards_edge,
                     "inwards",
                     dm.DirectRelationReference("pygen-models", "bidirectional"),
                     "inwards",
+                    dm.ViewId("pygen-models", "ConnectionItemA", "1"),
                 ),
                 (
                     self.self_edge_edge,
                     "self_edge",
                     dm.DirectRelationReference("pygen-models", "reflexive"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_c.py
+++ b/examples-pydantic-v1/omni_pydantic_v1/_api/connection_item_c.py
@@ -186,18 +186,20 @@ class ConnectionItemCAPI(NodeAPI[ConnectionItemC, ConnectionItemCWrite, Connecti
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.connection_item_a_edge,
                     "connection_item_a",
                     dm.DirectRelationReference("pygen-models", "unidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemA", "1"),
                 ),
                 (
                     self.connection_item_b_edge,
                     "connection_item_b",
                     dm.DirectRelationReference("pygen-models", "unidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )
@@ -242,18 +244,20 @@ class ConnectionItemCAPI(NodeAPI[ConnectionItemC, ConnectionItemCWrite, Connecti
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.connection_item_a_edge,
                     "connection_item_a",
                     dm.DirectRelationReference("pygen-models", "unidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemA", "1"),
                 ),
                 (
                     self.connection_item_b_edge,
                     "connection_item_b",
                     dm.DirectRelationReference("pygen-models", "unidirectional"),
                     "outwards",
+                    dm.ViewId("pygen-models", "ConnectionItemB", "1"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/omni_pydantic_v1/_api/dependent_on_non_writable.py
+++ b/examples-pydantic-v1/omni_pydantic_v1/_api/dependent_on_non_writable.py
@@ -196,12 +196,13 @@ class DependentOnNonWritableAPI(
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.to_non_writable_edge,
                     "to_non_writable",
                     dm.DirectRelationReference("pygen-models", "toNonWritable"),
                     "outwards",
+                    dm.ViewId("pygen-models", "Implementation1NonWriteable", "1"),
                 ),
             ],
         )
@@ -458,12 +459,13 @@ class DependentOnNonWritableAPI(
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.to_non_writable_edge,
                     "to_non_writable",
                     dm.DirectRelationReference("pygen-models", "toNonWritable"),
                     "outwards",
+                    dm.ViewId("pygen-models", "Implementation1NonWriteable", "1"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/scenario_instance_pydantic_v1/client/_api/_core.py
+++ b/examples-pydantic-v1/scenario_instance_pydantic_v1/client/_api/_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
+from itertools import groupby
 
 from collections import Counter, defaultdict, UserList
 from collections.abc import Sequence, Collection
@@ -101,8 +102,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str,
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | None: ...
 
@@ -112,8 +113,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModelList: ...
 
@@ -122,8 +123,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str | SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | T_DomainModelList | None:
         is_multiple = True
@@ -137,7 +138,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         nodes = self._class_list([self._class_type.from_instance(node) for node in instances.nodes])
 
         if retrieve_edges and nodes:
-            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_view_id_penta)
 
         if is_multiple:
             return nodes
@@ -304,7 +305,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         limit: int,
         filter: dm.Filter,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
+        edge_api_name_type_direction_view_id_penta: (
             list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
         ) = None,
     ) -> T_DomainModelList:
@@ -313,32 +314,62 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         )
         node_list = self._class_list([self._class_type.from_instance(node) for node in nodes])
         if retrieve_edges and node_list:
-            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_view_id_penta)
 
         return node_list
 
-    @classmethod
     def _retrieve_and_set_edge_types(
-        cls,
+        self,
         nodes: T_DomainModelList,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ):
-        for edge_api, edge_name, edge_type, direction in edge_api_name_type_direction_quad or []:
-            is_type = dm.filters.Equals(
-                ["edge", "type"],
-                {"space": edge_type.space, "externalId": edge_type.external_id},
-            )
-            if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
-                edges = edge_api._list(limit=-1, filter_=is_type)
-            else:
-                is_nodes = dm.filters.In(
-                    ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
-                    values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+        for edge_type, values in groupby(edge_api_name_type_direction_view_id_penta or [], lambda x: x[2].as_tuple()):
+            edges: dict[dm.EdgeId, dm.Edge] = {}
+            value_list = list(values)
+            for edge_api, edge_name, edge_type, direction, view_id in value_list:
+                is_type = dm.filters.Equals(
+                    ["edge", "type"],
+                    {"space": edge_type.space, "externalId": edge_type.external_id},
                 )
-                edges = edge_api._list(limit=-1, filter_=dm.filters.And(is_type, is_nodes))
-            cls._set_edges(nodes, edges, edge_name, direction)
+                if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
+                    filter_ = is_type
+                else:
+                    is_nodes = dm.filters.In(
+                        ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
+                        values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+                    )
+                    filter_ = dm.filters.And(is_type, is_nodes)
+                result = edge_api._list(limit=-1, filter_=filter_)
+                edges.update({edge.as_id(): edge for edge in result})
+            edge_list = list(edges.values())
+            if len(value_list) == 1:
+                _, edge_name, _, direction, _ = value_list[0]
+                self._set_edges(nodes, edge_list, edge_name, direction)
+            else:
+                # This is an 'edge' case where we have view with multiple edges of the same type.
+                edge_by_end_node: dict[tuple[str, str], list[dm.Edge]] = defaultdict(list)
+                for edge in edge_list:
+                    node_id = edge.end_node.as_tuple() if direction == "outwards" else edge.start_node.as_tuple()
+                    edge_by_end_node[node_id].append(edge)
+
+                for no, (edge_api, edge_name, _, direction, view_id) in enumerate(value_list):
+                    if not edge_by_end_node:
+                        break
+                    if no == len(value_list) - 1:
+                        # Last edge, use all remaining nodes
+                        attribute_edges = [e for e_list in edge_by_end_node.values() for e in e_list]
+                    else:
+                        existing = self._client.data_modeling.instances.retrieve(
+                            nodes=list(edge_by_end_node), sources=view_id
+                        )
+                        attribute_edges = []
+                        for node in existing.nodes:
+                            attribute_edge = edge_by_end_node.pop(node.as_id().as_tuple(), [])
+                            attribute_edges.extend(attribute_edge)
+
+                    self._set_edges(nodes, attribute_edges, edge_name, direction)
 
     @staticmethod
     def _set_edges(

--- a/examples-pydantic-v1/windmill_pydantic_v1/_api/_core.py
+++ b/examples-pydantic-v1/windmill_pydantic_v1/_api/_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import re
 import warnings
+from itertools import groupby
 
 from collections import Counter, defaultdict, UserList
 from collections.abc import Sequence, Collection
@@ -101,8 +102,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str,
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | None: ...
 
@@ -112,8 +113,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModelList: ...
 
@@ -122,8 +123,8 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         external_id: str | SequenceNotStr[str],
         space: str,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ) -> T_DomainModel | T_DomainModelList | None:
         is_multiple = True
@@ -137,7 +138,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         nodes = self._class_list([self._class_type.from_instance(node) for node in instances.nodes])
 
         if retrieve_edges and nodes:
-            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(nodes, edge_api_name_type_direction_view_id_penta)
 
         if is_multiple:
             return nodes
@@ -304,7 +305,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         limit: int,
         filter: dm.Filter,
         retrieve_edges: bool = False,
-        edge_api_name_type_direction_quad: (
+        edge_api_name_type_direction_view_id_penta: (
             list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
         ) = None,
     ) -> T_DomainModelList:
@@ -313,32 +314,62 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList]):
         )
         node_list = self._class_list([self._class_type.from_instance(node) for node in nodes])
         if retrieve_edges and node_list:
-            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_quad)
+            self._retrieve_and_set_edge_types(node_list, edge_api_name_type_direction_view_id_penta)
 
         return node_list
 
-    @classmethod
     def _retrieve_and_set_edge_types(
-        cls,
+        self,
         nodes: T_DomainModelList,
-        edge_api_name_type_direction_quad: (
-            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"]]] | None
+        edge_api_name_type_direction_view_id_penta: (
+            list[tuple[EdgeAPI, str, dm.DirectRelationReference, Literal["outwards", "inwards"], dm.ViewId]] | None
         ) = None,
     ):
-        for edge_api, edge_name, edge_type, direction in edge_api_name_type_direction_quad or []:
-            is_type = dm.filters.Equals(
-                ["edge", "type"],
-                {"space": edge_type.space, "externalId": edge_type.external_id},
-            )
-            if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
-                edges = edge_api._list(limit=-1, filter_=is_type)
-            else:
-                is_nodes = dm.filters.In(
-                    ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
-                    values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+        for edge_type, values in groupby(edge_api_name_type_direction_view_id_penta or [], lambda x: x[2].as_tuple()):
+            edges: dict[dm.EdgeId, dm.Edge] = {}
+            value_list = list(values)
+            for edge_api, edge_name, edge_type, direction, view_id in value_list:
+                is_type = dm.filters.Equals(
+                    ["edge", "type"],
+                    {"space": edge_type.space, "externalId": edge_type.external_id},
                 )
-                edges = edge_api._list(limit=-1, filter_=dm.filters.And(is_type, is_nodes))
-            cls._set_edges(nodes, edges, edge_name, direction)
+                if len(ids := nodes.as_node_ids()) > IN_FILTER_LIMIT:
+                    filter_ = is_type
+                else:
+                    is_nodes = dm.filters.In(
+                        ["edge", "startNode"] if direction == "outwards" else ["edge", "endNode"],
+                        values=[id_.dump(camel_case=True, include_instance_type=False) for id_ in ids],
+                    )
+                    filter_ = dm.filters.And(is_type, is_nodes)
+                result = edge_api._list(limit=-1, filter_=filter_)
+                edges.update({edge.as_id(): edge for edge in result})
+            edge_list = list(edges.values())
+            if len(value_list) == 1:
+                _, edge_name, _, direction, _ = value_list[0]
+                self._set_edges(nodes, edge_list, edge_name, direction)
+            else:
+                # This is an 'edge' case where we have view with multiple edges of the same type.
+                edge_by_end_node: dict[tuple[str, str], list[dm.Edge]] = defaultdict(list)
+                for edge in edge_list:
+                    node_id = edge.end_node.as_tuple() if direction == "outwards" else edge.start_node.as_tuple()
+                    edge_by_end_node[node_id].append(edge)
+
+                for no, (edge_api, edge_name, _, direction, view_id) in enumerate(value_list):
+                    if not edge_by_end_node:
+                        break
+                    if no == len(value_list) - 1:
+                        # Last edge, use all remaining nodes
+                        attribute_edges = [e for e_list in edge_by_end_node.values() for e in e_list]
+                    else:
+                        existing = self._client.data_modeling.instances.retrieve(
+                            nodes=list(edge_by_end_node), sources=view_id
+                        )
+                        attribute_edges = []
+                        for node in existing.nodes:
+                            attribute_edge = edge_by_end_node.pop(node.as_id().as_tuple(), [])
+                            attribute_edges.extend(attribute_edge)
+
+                    self._set_edges(nodes, attribute_edges, edge_name, direction)
 
     @staticmethod
     def _set_edges(

--- a/examples-pydantic-v1/windmill_pydantic_v1/_api/blade.py
+++ b/examples-pydantic-v1/windmill_pydantic_v1/_api/blade.py
@@ -195,12 +195,13 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList]):
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.sensor_positions_edge,
                     "sensor_positions",
                     dm.DirectRelationReference("power-models", "Blade.sensor_positions"),
                     "outwards",
+                    dm.ViewId("power-models", "SensorPosition", "1"),
                 ),
             ],
         )
@@ -469,12 +470,13 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList]):
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.sensor_positions_edge,
                     "sensor_positions",
                     dm.DirectRelationReference("power-models", "Blade.sensor_positions"),
                     "outwards",
+                    dm.ViewId("power-models", "SensorPosition", "1"),
                 ),
             ],
         )

--- a/examples-pydantic-v1/windmill_pydantic_v1/_api/windmill.py
+++ b/examples-pydantic-v1/windmill_pydantic_v1/_api/windmill.py
@@ -212,18 +212,20 @@ class WindmillAPI(NodeAPI[Windmill, WindmillWrite, WindmillList]):
             external_id,
             space,
             retrieve_edges=True,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.blades_edge,
                     "blades",
                     dm.DirectRelationReference("power-models", "Windmill.blades"),
                     "outwards",
+                    dm.ViewId("power-models", "Blade", "1"),
                 ),
                 (
                     self.metmast_edge,
                     "metmast",
                     dm.DirectRelationReference("power-models", "Windmill.metmast"),
                     "outwards",
+                    dm.ViewId("power-models", "Metmast", "1"),
                 ),
             ],
         )
@@ -562,18 +564,20 @@ class WindmillAPI(NodeAPI[Windmill, WindmillWrite, WindmillList]):
             limit=limit,
             filter=filter_,
             retrieve_edges=retrieve_edges,
-            edge_api_name_type_direction_quad=[
+            edge_api_name_type_direction_view_id_penta=[
                 (
                     self.blades_edge,
                     "blades",
                     dm.DirectRelationReference("power-models", "Windmill.blades"),
                     "outwards",
+                    dm.ViewId("power-models", "Blade", "1"),
                 ),
                 (
                     self.metmast_edge,
                     "metmast",
                     dm.DirectRelationReference("power-models", "Windmill.metmast"),
                     "outwards",
+                    dm.ViewId("power-models", "Metmast", "1"),
                 ),
             ],
         )


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
- [ ] Regenerate example SDK `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
