### PR TITLE
[PYG-144, PYG-139] Setup coverage test

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,8 +7,8 @@ labels: bug
 ---
 **System information (please complete the following information):**
  - OS: [e.g. Darwin/18.0.0-x86_64-64bit]
- - Python Version: [e.g. CPython/3.7.2;Clang 10.0.0]
- - gql-pygen Version: [e.g. 0.13.0.a4]
+ - Python Version: [e.g. 3.11;]
+ - cognite-pygen Version: [e.g. 0.99.15]
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -21,7 +21,6 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
-
 
 
 **Additional context**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,10 +85,6 @@ jobs:
       - name: Test CLI
         run: pygen --help
 
-      - uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.xml
-
       - name: Build package
         run: poetry build
 
@@ -113,3 +109,28 @@ jobs:
 
       - name: Test CLI
         run: pygen --help
+
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip poetry
+          poetry config virtualenvs.create false
+          poetry install -E all
+
+      - name: Test
+        run: pytest --cov=cognite/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/test_unit
+
+      - name: Push coverage report to PR
+        uses: orgoro/coverage@v3.1
+        with:
+            coverageFile: coverage.xml
+            token: ${{ secrets.GITHUB_TOKEN }}
+            thresholdAll: 0.6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    environment: dev
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-python@v5
@@ -126,7 +127,13 @@ jobs:
           poetry install -E all
 
       - name: Test
-        run: pytest --cov=cognite/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/test_unit
+        env:
+          CDF_CLUSTER: ${{ vars.CDF_CLUSTER }}
+          CDF_PROJECT: ${{ vars.CDF_PROJECT }}
+          IDP_CLIENT_ID: ${{ vars.IDP_CLIENT_ID }}
+          IDP_CLIENT_SECRET: ${{ secrets.IDP_CLIENT_SECRET }}
+          IDP_TENANT_ID: ${{ secrets.IDP_TENANT_ID }}
+        run: pytest --cov=cognite/ --cov-config=pyproject.toml --cov-report=xml:coverage.xml tests/
 
       - name: Push coverage report to PR
         uses: orgoro/coverage@v3.1

--- a/tests/test_integration/conftest.py
+++ b/tests/test_integration/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import getpass
+import os
 from pathlib import Path
 
 import pytest
@@ -21,7 +22,17 @@ else:
 
 @pytest.fixture(scope="session")
 def client_config() -> dict[str, str]:
-    return toml.load(Path(__file__).parent / "config.toml")["cognite"]
+    config_file = Path(__file__).parent / "config.toml"
+    if config_file.exists():
+        return toml.load(config_file)["cognite"]
+    else:
+        return {
+            "tenant_id": os.environ["IDP_TENANT_ID"],
+            "client_id": os.environ["IDP_CLIENT_ID"],
+            "client_secret": os.environ["IDP_CLIENT_SECRET"],
+            "cdf_cluster": os.environ["CDF_CLUSTER"],
+            "project": os.environ["CDF_PROJECT"],
+        }
 
 
 def create_cognite_client_config(


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/cognite-gql-pygen/blob/main/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in
  [version.py](https://github.com/cognitedata/cognite-gql-pygen/blob/main/cognite/gqlpygen/version.py) and
  [pyproject.toml](https://github.com/cognitedata/cognite-gql-pygen/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
- [ ] Regenerate example SDK `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
