### PR TITLE
[PYG-125] 🐼Fix hyphen and start with digit in Python property names

### DIFF
--- a/cognite/pygen/_core/models/api_classes.py
+++ b/cognite/pygen/_core/models/api_classes.py
@@ -179,7 +179,7 @@ class EdgeAPIClass(APIClass):
             start_class=data_class,
             end_class=end_class,
             filter_method=filter_method,
-            doc_name=create_name(field.name, api_class.doc_name),
+            doc_name=create_name(field.name, api_class.doc_name, python_variable=False),
             query=query_class_by_view_id[end_class.view_id],
             direction=field.edge_direction,
             end_view_id=end_class.view_id,

--- a/cognite/pygen/utils/text.py
+++ b/cognite/pygen/utils/text.py
@@ -7,13 +7,14 @@ import inflect
 from cognite.pygen.config import Case, Naming, Number
 
 
-def create_name(raw_name: str, naming: Naming) -> str:
+def create_name(raw_name: str, naming: Naming, python_variable: bool = True) -> str:
     """
     Create a name from a raw name and following the given naming convention.
 
     Args:
         raw_name: The raw string to convert.
         naming: The naming convention to follow.
+        python_variable: Whether to convert to a valid Python variable name.
 
     Returns:
         The converted name.
@@ -21,6 +22,12 @@ def create_name(raw_name: str, naming: Naming) -> str:
     """
     is_plural = naming.number == Number.plural
     is_singular = naming.number == Number.singular
+    if python_variable:
+        if raw_name and raw_name[0].isdigit():
+            raw_name = f"no{raw_name}"
+        if "-" in raw_name:
+            raw_name = raw_name.replace("-", "_")
+
     if naming.case is Case.pascal:
         return to_pascal(raw_name, is_plural, is_singular)
     elif naming.case is Case.snake:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,9 @@ Changes are grouped as follows
 - Edges with properties now correctly generates the end_node field for direction `inwards`.
 - Edges with properties now have the correct destination node when multiple edge properties
   have the same edge type.
+- If a view property starts with a digit or contains a hyphen, the generated data class will
+  now have the property name prefixed with `no_` to make it a valid Python variable name instead
+  of raising an exception.
 
 ## [0.99.30] - 24-08-13
 ### Added

--- a/tests/test_unit/test_api/test_generate_sdk.py
+++ b/tests/test_unit/test_api/test_generate_sdk.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 
 from cognite.client import data_modeling as dm
 
@@ -39,6 +40,22 @@ class TestGenerateSDK:
 
         generate_sdk(
             DATA_MODEL_WITH_VIEW_WITHOUT_PROPERTIES,
+            top_level_package=top_level_package,
+            output_dir=tmp_path,
+            overwrite=True,
+            client_name=client_name,
+        )
+
+        with append_to_sys_path(str(tmp_path)):
+            module = vars(importlib.import_module(top_level_package))
+            assert client_name in module
+
+    def test_generate_sdk_with_illegal_property_names(self, tmp_path: Path) -> None:
+        client_name = "IllegalPropertyNamesClient"
+        top_level_package = "illegal_property_names_model"
+
+        generate_sdk(
+            DATA_MODEL_WITH_ILLEGAL_PROPERTY_NAMES,
             top_level_package=top_level_package,
             output_dir=tmp_path,
             overwrite=True,
@@ -136,6 +153,51 @@ DATA_MODEL_WITH_VIEW_WITHOUT_PROPERTIES = dm.DataModel(
             external_id="NoProperties",
             version="1",
             properties={},
+            description=None,
+            is_global=False,
+            last_updated_time=0,
+            created_time=0,
+            used_for="node",
+            implements=None,
+            writable=True,
+            filter=None,
+        )
+    ],
+)
+
+DATA_MODEL_WITH_ILLEGAL_PROPERTY_NAMES = dm.DataModel(
+    space="illegal_property_names_space",
+    external_id="IllegalPropertyNamesModel",
+    version="1",
+    is_global=False,
+    last_updated_time=0,
+    created_time=0,
+    description=None,
+    name=None,
+    views=[
+        dm.View(
+            space="illegal_property_names_space",
+            name="IllegalPropertyNames",
+            external_id="IllegalPropertyNames",
+            version="1",
+            properties={
+                "name-tag": dm.MappedProperty(
+                    container=dm.ContainerId("illegal_property_names_space", "IllegalPropertyNames"),
+                    container_property_identifier="name",
+                    type=dm.Text(),
+                    nullable=False,
+                    auto_increment=False,
+                    immutable=False,
+                ),
+                "3d-field": dm.MappedProperty(
+                    container=dm.ContainerId("illegal_property_names_space", "IllegalPropertyNames"),
+                    container_property_identifier="field",
+                    type=dm.Text(),
+                    nullable=True,
+                    auto_increment=False,
+                    immutable=False,
+                ),
+            },
             description=None,
             is_global=False,
             last_updated_time=0,


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
