### PR TITLE
[PYG-224] 🤦Hack for skipping readonly fields in Typed Classes

### DIFF
--- a/cognite/pygen/_core/generators.py
+++ b/cognite/pygen/_core/generators.py
@@ -566,15 +566,21 @@ class MultiAPIGenerator:
         )
 
     def generate_typed_classes_file(
-        self, include: set[dm.ViewId] | None = None, module_by_space: dict[str, str] | None = None
+        self,
+        include: set[dm.ViewId] | None = None,
+        module_by_space: dict[str, str] | None = None,
+        readonly_properties_by_view: dict[dm.ViewId, set[str]] | None = None,
     ) -> str:
         """Generate the typed classes file for the SDK.
 
         Args:
             include: The set of view IDs to include in the generated typed classes file.
                 If None, all views will be included.
-            module_by_space: A dictionary mapping space to module. If this is passed, the views in the given
-                space will be skipped and imported from the given module instead.
+            module_by_space: A dictionary mapping space names to module names. This is used if part of the data model
+                has been generated before and you want to reuse the generated classes. The keys are the space names
+                and the values are the module names. For example, {"cdf_cdm": "cognite.client.data_classes.cdm.v1"},
+                this will import all classes generated from views in the 'cdf_cdm' space from the
+                'cognite.client.data_classes.cdm.v1' module.
 
         Returns:
             The generated typed classes file as a string.
@@ -626,6 +632,7 @@ class MultiAPIGenerator:
                 has_datetime_import=bool(datetime_import),
                 len=len,
                 parent_classes_by_module=parent_classes_by_module,
+                readonly_properties_by_view=readonly_properties_by_view or {},
             )
             + "\n"
         )

--- a/cognite/pygen/_core/generators.py
+++ b/cognite/pygen/_core/generators.py
@@ -570,6 +570,12 @@ class MultiAPIGenerator:
     ) -> str:
         """Generate the typed classes file for the SDK.
 
+        Args:
+            include: The set of view IDs to include in the generated typed classes file.
+                If None, all views will be included.
+            module_by_space: A dictionary mapping space to module. If this is passed, the views in the given
+                space will be skipped and imported from the given module instead.
+
         Returns:
             The generated typed classes file as a string.
         """

--- a/cognite/pygen/_core/generators.py
+++ b/cognite/pygen/_core/generators.py
@@ -581,6 +581,7 @@ class MultiAPIGenerator:
                 and the values are the module names. For example, {"cdf_cdm": "cognite.client.data_classes.cdm.v1"},
                 this will import all classes generated from views in the 'cdf_cdm' space from the
                 'cognite.client.data_classes.cdm.v1' module.
+            readonly_properties_by_view: A dictionary mapping view IDs to a set of readonly properties for that view.
 
         Returns:
             The generated typed classes file as a string.

--- a/cognite/pygen/_core/templates/typed_classes.py.jinja
+++ b/cognite/pygen/_core/templates/typed_classes.py.jinja
@@ -34,8 +34,8 @@ class {{ cls.read_name }}Apply({{ cls.typed_properties_name }}, {{ cls.typed_wri
     {{ cls.description }}{% endif %}
     Args:
         space: The space where the node is located.
-        external_id: The external id of the {{ cls.doc_name }}.{% for field in cls.container_fields_sorted() %}
-        {{ field.name }}: {{ field.argument_documentation }}{% endfor %}
+        external_id: The external id of the {{ cls.doc_name }}.{% for field in cls.container_fields_sorted() %}{% if not readonly_properties_by_view.get(cls.view_id) or field.prop_name not in readonly_properties_by_view.get(cls.view_id)  %}
+        {{ field.name }}: {{ field.argument_documentation }}{% endif %}{% endfor %}
         existing_version: Fail the ingestion request if the node's version is greater than or equal to this value.
             If no existingVersion is specified, the ingestion will always overwrite any existing data for the node
             (for the specified container or node). If existingVersion is set to 0, the upsert will behave as an insert,
@@ -47,15 +47,15 @@ class {{ cls.read_name }}Apply({{ cls.typed_properties_name }}, {{ cls.typed_wri
         self,
         space: str,
         external_id: str,
-        *,{% for field in cls.container_fields_sorted() %}
-        {{field.name}}: {{ field.as_typed_hint() }},{% endfor %}
+        *,{% for field in cls.container_fields_sorted() %}{% if not readonly_properties_by_view.get(cls.view_id) or field.prop_name not in readonly_properties_by_view.get(cls.view_id)  %}
+        {{field.name}}: {{ field.as_typed_hint() }},{% endif %}{% endfor %}
         existing_version: int | None = None,
         type: DirectRelationReference | tuple[str, str] | None = None,
     ) -> None:{% if len(cls.implements) == 0 %}
         TypedNodeApply.__init__(self, space, external_id, existing_version, None, type){% elif len(cls.implements) == 1 %}
         super().__init__(space, external_id,{{ cls.implements[0].container_field_variables }}, existing_version=existing_version, type=type){% else %}{% for parent in cls.implements %}
-        {{ parent.read_name }}Apply.__init__(self, space, external_id, {{ parent.container_field_variables }}, existing_version=existing_version, type=type){% endfor %}{% endif %}{% for field in cls.container_fields_sorted('only-self') %}
-        self.{{field.name}} = {{field.as_typed_init_set()}}{% endfor %}
+        {{ parent.read_name }}Apply.__init__(self, space, external_id, {{ parent.container_field_variables }}, existing_version=existing_version, type=type){% endfor %}{% endif %}{% for field in cls.container_fields_sorted('only-self') %}{% if not readonly_properties_by_view.get(cls.view_id) or field.prop_name not in readonly_properties_by_view.get(cls.view_id)  %}
+        self.{{field.name}} = {{field.as_typed_init_set()}}{% endif %}{% endfor %}
 
 
 class {{ cls.read_name }}({{ cls.typed_properties_name }}, {{ cls.typed_read_bases_classes }}):

--- a/cognite/pygen/_core/templates/typed_classes.py.jinja
+++ b/cognite/pygen/_core/templates/typed_classes.py.jinja
@@ -96,8 +96,8 @@ class {{ cls.read_name }}({{ cls.typed_properties_name }}, {{ cls.typed_read_bas
     def as_write(self) -> {{ cls.read_name }}Apply:
         return {{ cls.read_name }}Apply(
             self.space,
-            self.external_id,{% for field in cls.container_fields_sorted() %}
-            {{field.name}}=self.{{field.name}},{% if field.is_connection and field.is_one_to_many %}  # type: ignore[arg-type]{% endif %}{% endfor %}
+            self.external_id,{% for field in cls.container_fields_sorted() %}{% if not readonly_properties_by_view.get(cls.view_id) or field.prop_name not in readonly_properties_by_view.get(cls.view_id)  %}
+            {{field.name}}=self.{{field.name}},{% if field.is_connection and field.is_one_to_many %}  # type: ignore[arg-type]{% endif %}{% endif %}{% endfor %}
             existing_version=self.version,
             type=self.type,
         )

--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -461,6 +461,7 @@ def generate_typed(
     format_code: bool = True,
     include_views: set[dm.ViewId] | None = None,
     module_by_space: dict[str, str] | None = None,
+    readonly_properties_by_view: dict[dm.ViewId, set[str]] | None = None,
 ) -> str | None:
     """Generates typed classes for all views in the given data model.
 
@@ -475,6 +476,7 @@ def generate_typed(
             and the values are the module names. For example, {"cdf_cdm": "cognite.client.data_classes.cdm.v1"},
             this will import all classes generated from views in the 'cdf_cdm' space from the
             'cognite.client.data_classes.cdm.v1' module.
+        readonly_properties_by_view: A dictionary mapping view IDs to a set of property names that should be read-only.
 
     Returns:
         If output_file is None, the typed classes as a string. Otherwise, None.
@@ -490,7 +492,9 @@ def generate_typed(
         print,
         PygenConfig(),
     )
-    typed_classes = generator._multi_api_generator.generate_typed_classes_file(include_views, module_by_space)
+    typed_classes = generator._multi_api_generator.generate_typed_classes_file(
+        include_views, module_by_space, readonly_properties_by_view
+    )
 
     if format_code:
         formatter = CodeFormatter(format_code, print)

--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -441,6 +441,8 @@ def generate_typed(
     client: Optional[CogniteClient] = None,
     format_code: bool = True,
     include_views: set[dm.ViewId] | None = None,
+    module_by_space: dict[str, str] | None = None,
+    readonly_properties_by_view: dict[dm.ViewId, set[str]] | None = None,
 ) -> None: ...
 
 
@@ -451,6 +453,8 @@ def generate_typed(
     client: Optional[CogniteClient] = None,
     format_code: bool = True,
     include_views: set[dm.ViewId] | None = None,
+    module_by_space: dict[str, str] | None = None,
+    readonly_properties_by_view: dict[dm.ViewId, set[str]] | None = None,
 ) -> str: ...
 
 


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
