### PR TITLE
Enable specifying a import_prefix for generated modules

### DIFF
--- a/cognite/pygen/_core/generators.py
+++ b/cognite/pygen/_core/generators.py
@@ -55,8 +55,10 @@ class SDKGenerator:
         implements: Literal["inheritance", "composition"] = "inheritance",
         logger: Callable[[str], None] | None = None,
         config: PygenConfig = PygenConfig(),
+        import_prefix: str | None = None,
     ):
         self.top_level_package = top_level_package
+        self.import_prefix = import_prefix
         self.client_name = client_name
         self._multi_api_classes: list[MultiAPIClass]
         if isinstance(data_model, dm.DataModel):
@@ -201,9 +203,11 @@ class MultiAPIGenerator:
         implements: Literal["inheritance", "composition"] = "inheritance",
         logger: Callable[[str], None] | None = None,
         config: PygenConfig = PygenConfig(),
+        import_prefix: str | None = None,
     ):
         self.env = Environment(loader=PackageLoader("cognite.pygen._core", "templates"), autoescape=select_autoescape())
         self.top_level_package = top_level_package
+        self.import_prefix = import_prefix
         self.client_name = client_name
         self.default_instance_space = default_instance_space
         self._implements = implements
@@ -807,12 +811,13 @@ class APIGenerator:
             + "\n"
         )
 
-    def generate_api_file(self, top_level_package: str, client_name: str) -> str:
+    def generate_api_file(self, top_level_package: str, client_name: str, import_prefix: str | None = None) -> str:
         """Generate the API file for the view.
 
         Args:
             top_level_package: The top level package for the SDK.
             client_name: The name of the client class.
+            import_prefix: Import prefix, prepended to all relative imports.
 
         Returns:
             The generated API file as a string.
@@ -836,11 +841,14 @@ class APIGenerator:
                 # ft = field types
                 ft=fields,
                 dm=dm,
+                import_prefix=import_prefix,
             )
             + "\n"
         )
 
-    def generate_api_query_file(self, top_level_package: str, client_name: str) -> str:
+    def generate_api_query_file(
+        self, top_level_package: str, client_name: str, import_prefix: str | None = None
+    ) -> str:
         """Generate the API query file for the view.
 
         This is the basis for the Python query functionality for the view.
@@ -848,6 +856,7 @@ class APIGenerator:
         Args:
             top_level_package: The top level package for the SDK.
             client_name: The name of the client class.
+            import_prefix: Import prefix, prepended to all relative imports.
 
         Returns:
             The generated API query file as a string.
@@ -871,23 +880,27 @@ class APIGenerator:
                 ft=fields,
                 dm=dm,
                 sorted=sorted,
+                import_prefix=import_prefix,
             )
             + "\n"
         )
 
-    def generate_edge_api_files(self, top_level_package: str, client_name: str) -> Iterator[tuple[str, str]]:
+    def generate_edge_api_files(
+        self, top_level_package: str, client_name: str, import_prefix: str | None = None
+    ) -> Iterator[tuple[str, str]]:
         """Generate the edge API files for the view.
 
 
         Args:
             top_level_package: The top level package for the SDK.
             client_name: The name of the client class.
+            import_prefix: Import prefix, prepended to all relative.
 
         Returns:
             Iterator of tuples of file names and file contents for the edge APIs.
         """
 
-        edge_class = self._env.get_template("api_class_edge.py.jinja")
+        edge_class = self._env.get_template("api_class_query.py.jinja")
         for edge_api in self.edge_apis:
             yield (
                 edge_api.file_name,
@@ -901,17 +914,21 @@ class APIGenerator:
                         # ft = field types
                         ft=fields,
                         dm=dm,
+                        import_prefix=import_prefix,
                     )
                     + "\n"
                 ),
             )
 
-    def generate_timeseries_api_files(self, top_level_package: str, client_name: str) -> Iterator[tuple[str, str]]:
+    def generate_timeseries_api_files(
+        self, top_level_package: str, client_name: str, import_prefix: str | None = None
+    ) -> Iterator[tuple[str, str]]:
         """Generate the timeseries API files for the view.
 
         Args:
             top_level_package: The top level package for the SDK.
             client_name: The name of the client class.
+            import_prefix: Import prefix, prepended to all relative imports.
 
         Returns:
             Iterator of tuples of file names and file contents for the timeseries APIs.
@@ -931,6 +948,7 @@ class APIGenerator:
                         # ft = field types
                         ft=fields,
                         dm=dm,
+                        import_prefix=import_prefix,
                     )
                     + "\n"
                 ),

--- a/cognite/pygen/_core/templates/_api_client_multi_model.py.jinja
+++ b/cognite/pygen/_core/templates/_api_client_multi_model.py.jinja
@@ -8,12 +8,15 @@ from cognite.client import ClientConfig, CogniteClient, data_modeling as dm
 from cognite.client.data_classes import TimeSeriesList, FileMetadataList, SequenceList
 from cognite.client.credentials import OAuthClientCredentials
 
-from ._api import ({% for api in api_classes %}{% if not api.data_class.is_edge_class %}
+
+from {{ import_path }}._api import ({% for api in api_classes %}{% if not api.data_class.is_edge_class %}
     {{ api.api_class.name }},{% endif %}{% endfor %}
 )
-from ._api._core import SequenceNotStr, GraphQLQueryResponse
-from .data_classes._core import {% if has_default_instance_space %}DEFAULT_INSTANCE_SPACE, {% endif %}GraphQLList
-from . import data_classes
+from {{ import_path }}._api._core import SequenceNotStr, GraphQLQueryResponse
+from {{ import_path }}.data_classes._core import {% if has_default_instance_space %}DEFAULT_INSTANCE_SPACE, {% endif %}GraphQLList
+from {{ import_path }}. import data_classes
+
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
 
 {% for api in multi_apis %}
 class {{ api.name }}:
@@ -188,7 +191,7 @@ class {{ client_name }}:
 
             Delete item by id:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> client.delete("my_node_external_id")
         """{% if not has_default_instance_space %}

--- a/cognite/pygen/_core/templates/_api_client_single_model.py.jinja
+++ b/cognite/pygen/_core/templates/_api_client_single_model.py.jinja
@@ -15,6 +15,7 @@ from ._api._core import SequenceNotStr, GraphQLQueryResponse
 from .data_classes._core import {% if has_default_instance_space %}DEFAULT_INSTANCE_SPACE, {% endif %}GraphQLList
 from . import data_classes
 
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
 
 class {{ client_name }}:
     """
@@ -163,7 +164,7 @@ class {{ client_name }}:
 
             Delete item by id:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> client.delete("my_node_external_id")
         """{% if not has_default_instance_space %}

--- a/cognite/pygen/_core/templates/_client_init.py.jinja
+++ b/cognite/pygen/_core/templates/_client_init.py.jinja
@@ -1,3 +1,4 @@
-from {{ top_level_package }}._api_client import {{ client_name }}
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+from {{ import_path }}._api_client import {{ client_name }}
 
 __all__ = ["{{ client_name }}"]

--- a/cognite/pygen/_core/templates/api_class_edge.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_edge.py.jinja
@@ -2,17 +2,19 @@ from __future__ import annotations
 {% if edge_api.has_edge_class and  edge_api.edge_class.has_primitive_field_of_type((dm.Timestamp, dm.Date)) %}
 import datetime{% endif %}
 
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+
 from cognite.client import data_modeling as dm
 {% if edge_api.has_edge_class %}
-from {{ top_level_package }}.data_classes import (
+from {{ import_path }}.data_classes import (
     {{ edge_api.edge_class.read_name }},
     {{ edge_api.edge_class.read_list_name }},
     {{ edge_api.edge_class.write_name }},
 )
-from {{ top_level_package }}.data_classes.{{ edge_api.edge_class.file_name }} import {{ edge_api.edge_class.filter_name }}
+from {{ import_path }}.data_classes.{{ edge_api.edge_class.file_name }} import {{ edge_api.edge_class.filter_name }}
 {% endif %}
-from ._core import DEFAULT_LIMIT_READ, {% if edge_api.has_edge_class %}EdgePropertyAPI{% else %}EdgeAPI, _create_edge_filter{% endif %}{% if has_default_instance_space %}
-from {{ top_level_package }}.data_classes._core import DEFAULT_INSTANCE_SPACE{% endif %}
+from {{ import_path }}._core import DEFAULT_LIMIT_READ, {% if edge_api.has_edge_class %}EdgePropertyAPI{% else %}EdgeAPI, _create_edge_filter{% endif %}{% if has_default_instance_space %}
+from {{ import_path }}.data_classes._core import DEFAULT_INSTANCE_SPACE{% endif %}
 
 
 class {{ edge_api.name }}({% if edge_api.has_edge_class %}EdgePropertyAPI{% else %}EdgeAPI{% endif %}):{% if edge_api.has_edge_class %}
@@ -40,7 +42,7 @@ class {{ edge_api.name }}({% if edge_api.has_edge_class %}EdgePropertyAPI{% else
 
             List 5 {{edge_api.doc_name}} edges connected to "my_{{ edge_api.start_class.variable }}":
 
-                >>> from {{ top_level_package }} import {{ client_name }}{% if not has_default_instance_space %}
+                >>> from {{ import_path }} import {{ client_name }}{% if not has_default_instance_space %}
                 >>> from cognite.client import data_modeling as dm{% endif %}
                 >>> client = {{ client_name }}()
                 >>> {{ edge_api.start_class.variable }} = client.{{ api_class.parent_attribute }}.{{ edge_api.parent_attribute }}.list({% if has_default_instance_space %}"my_{{ edge_api.start_class.variable }}"{% else %}dm.NodeId("my_space", "my_connection_item_a"){% endif %}, limit=5)

--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -9,14 +9,16 @@ from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes.data_modeling.instances import InstanceAggregationResultList, InstanceSort
 
-from {{ top_level_package }}.data_classes._core import ({% if has_default_instance_space %}
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+
+from {{ import_path }}.data_classes._core import ({% if has_default_instance_space %}
     DEFAULT_INSTANCE_SPACE,{% endif %}
     DEFAULT_QUERY_LIMIT,
     NodeQueryStep,
     EdgeQueryStep,
     DataClassQueryBuilder,
 )
-from {{ top_level_package }}.data_classes import (
+from {{ import_path }}.data_classes import (
     DomainModelCore,
     DomainModelWrite,
     ResourcesWriteResult,
@@ -32,7 +34,7 @@ from {{ top_level_package }}.data_classes import (
     {{ dependency.read_name }},{% endif %}{% endfor %}{% for child in data_class.direct_children %}
     {{ child.read_name }},{% endfor %}
 )
-from {{ top_level_package }}.data_classes.{{ data_class.file_name }} import (
+from {{ import_path }}.data_classes.{{ data_class.file_name }} import (
     {{ data_class.query_cls_name }},{% if not data_class.has_only_one_to_many_edges and data_class.has_field_of_type(ft.BasePrimitiveField) %}
     {{ data_class.properties_dict_name }},{%  endif %}
     {{ data_class.filter_name }},
@@ -116,8 +118,8 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
             Create a new {{ data_class.variable }}:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
-                >>> from {{ top_level_package }}.data_classes import {{ data_class.write_name }}
+                >>> from {{ import_path }} import {{ client_name }}
+                >>> from {{ import_path }}.data_classes import {{ data_class.write_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }} = {{ data_class.write_name }}(external_id="my_{{ data_class.variable }}", ...)
                 >>> result = client.{{ api_class.parent_attribute }}.apply({{ data_class.variable }})
@@ -149,7 +151,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
             Delete {{ data_class.variable }} by id:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> client.{{ api_class.parent_attribute }}.delete("my_{{ data_class.variable }}")
         """
@@ -189,7 +191,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
             Retrieve {{ data_class.variable }} by id:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }} = client.{{ api_class.parent_attribute }}.retrieve("my_{{ data_class.variable }}")
 
@@ -244,7 +246,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
            Search for 'my_{{ data_class.variable }}' in all text properties:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable_list }} = client.{{ api_class.parent_attribute }}.search('my_{{ data_class.variable }}')
 
@@ -344,7 +346,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
             Count {{ data_class.doc_list_name }} in space `my_space`:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> result = client.{{ api_class.parent_attribute }}.aggregate("count", space="my_space")
 
@@ -445,7 +447,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
 
             List {{ data_class.doc_list_name }} and limit to 5:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable_list }} = client.{{ api_class.parent_attribute }}.list(limit=5)
 

--- a/cognite/pygen/_core/templates/api_class_query.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_query.py.jinja
@@ -6,13 +6,15 @@ from typing import TYPE_CHECKING, cast
 
 from cognite.client import data_modeling as dm, CogniteClient
 
-from {{ top_level_package }}.data_classes import (
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+
+from {{ import_path }}.data_classes import (
     DomainModelCore,
     {{ data_class.read_name }},{% for class_ in unique_edge_data_classes %}
     {{ class_.read_name }},{% endfor %}{% for field in data_class.one_to_one_direct_relations_with_source %}
     {{ field.destination_class.read_name }},{% endfor %}
 ){% for edge_api in edge_apis %}
-from {{ top_level_package }}.data_classes.{{ edge_api.end_class.file_name }} import (
+from {{ import_path }}.data_classes.{{ edge_api.end_class.file_name }} import (
     {{ edge_api.end_class.read_name }},
     {{ edge_api.end_class.filter_name }},
 ){% endfor %}
@@ -26,7 +28,7 @@ from ._core import (
     _create_edge_filter,{% endif %}
 )
 {% for class_ in unique_edge_data_classes %}
-from {{ top_level_package }}.data_classes.{{ class_.file_name }} import (
+from {{ import_path }}.data_classes.{{ class_.file_name }} import (
     {{ class_.filter_name }},
 ){% endfor %}{% if has_edge_api_dependencies %}
 if TYPE_CHECKING:{% for edge_api in edge_apis %}{% if edge_api.end_view_id != api_class.view_id %}

--- a/cognite/pygen/_core/templates/api_class_timeseries.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_timeseries.py.jinja
@@ -9,8 +9,11 @@ from cognite.client import CogniteClient
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import Datapoints, DatapointsArrayList, DatapointsList, TimeSeriesList
 from cognite.client.data_classes.datapoints import Aggregate
-from {{ top_level_package }}.data_classes.{{ data_class.file_name }} import {{ data_class.filter_name }}
-from {{ top_level_package }}.data_classes._core import QueryStep, DataClassQueryBuilder, DomainModelList
+
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+
+from {{ import_path }}.data_classes.{{ data_class.file_name }} import {{ data_class.filter_name }}
+from {{ import_path }}.data_classes._core import QueryStep, DataClassQueryBuilder, DomainModelList
 from ._core import DEFAULT_LIMIT_READ
 
 
@@ -68,7 +71,7 @@ class {{ timeseries_api.query_class}}:
             In this example,
             we are using the time-ago format to get raw data for the 'my_{{ timeseries_api.parent_attribute }}' from 2 weeks ago up until now::
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }}_datapoints = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}(external_id="my_{{ timeseries_api.parent_attribute }}").retrieve(start="2w-ago")
         """
@@ -128,7 +131,7 @@ class {{ timeseries_api.query_class}}:
             In this example,
             we are using the time-ago format to get raw data for the 'my_{{ timeseries_api.parent_attribute }}' from 2 weeks ago up until now::
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }}_datapoints = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}(external_id="my_{{ timeseries_api.parent_attribute }}").retrieve_array(start="2w-ago")
         """
@@ -197,7 +200,7 @@ class {{ timeseries_api.query_class}}:
             In this example,
             we are using the time-ago format to get raw data for the 'my_{{ timeseries_api.parent_attribute }}' from 2 weeks ago up until now::
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }}_datapoints = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}(external_id="my_{{ timeseries_api.parent_attribute }}").retrieve_dataframe(start="2w-ago")
         """
@@ -274,7 +277,7 @@ class {{ timeseries_api.query_class}}:
             In this example,
             get weekly aggregates for the 'my_{{ timeseries_api.parent_attribute }}' for the first month of 2023 in Oslo time:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> from datetime import datetime, timezone
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable }}_datapoints = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}(
@@ -381,7 +384,7 @@ class {{ timeseries_api.name}}:
 
             Retrieve all data for 5 {{ data_class.variable }}.{{ timeseries_api.parent_attribute }} timeseries:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable_list }} = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}(limit=5).retrieve()
 
@@ -419,7 +422,7 @@ class {{ timeseries_api.name}}:
 
             List {{ data_class.variable }}.{{ timeseries_api.parent_attribute }} and limit to 5:
 
-                >>> from {{ top_level_package }} import {{ client_name }}
+                >>> from {{ import_path }} import {{ client_name }}
                 >>> client = {{ client_name }}()
                 >>> {{ data_class.variable_list }} = client.{{ api_class.parent_attribute }}.{{ timeseries_api.parent_attribute }}.list(limit=5)
 

--- a/cognite/pygen/_core/templates/api_core.py.jinja
+++ b/cognite/pygen/_core/templates/api_core.py.jinja
@@ -21,8 +21,9 @@ from cognite.client import data_modeling as dm
 from cognite.client.data_classes import TimeSeriesList
 from cognite.client.data_classes.data_modeling.instances import InstanceSort, InstanceAggregationResultList
 
-from {{ top_level_package }} import data_classes
-from {{ top_level_package }}.data_classes._core import (
+{% set import_path = import_prefix + "." if import_prefix else "" + top_level_package %}
+from {{ import_path }} import data_classes
+from {{ import_path }}.data_classes._core import (
     DomainModel,
     DomainModelWrite,{% if has_default_instance_space %}
     DEFAULT_INSTANCE_SPACE,{% endif %}

--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -43,6 +43,7 @@ def generate_sdk(  # type: ignore[overload-overlap, misc]
     format_code: bool = True,
     config: Optional[PygenConfig] = None,
     return_sdk_files: Literal[False] = False,
+    import_prefix: Optional[str] = None,
 ) -> None: ...
 
 
@@ -59,6 +60,7 @@ def generate_sdk(
     format_code: bool = True,
     config: Optional[PygenConfig] = None,
     return_sdk_files: Literal[True] = False,  # type: ignore[assignment]
+    import_prefix: Optional[str] = None,
 ) -> dict[Path, str]: ...
 
 
@@ -74,6 +76,7 @@ def generate_sdk(
     format_code: bool = True,
     config: Optional[PygenConfig] = None,
     return_sdk_files: bool = False,
+    import_prefix: Optional[str] = None,
 ) -> None | dict[Path, str]:
     """
     Generates a Python SDK tailored to the given Data Model(s).
@@ -98,6 +101,7 @@ def generate_sdk(
         config: The configuration used to control how to generate the SDK.
         return_sdk_files: Whether to return the generated SDK files as a dictionary. Defaults to False.
             This is useful for granular control of how to write the SDK to disk.
+        import_prefix: prefix to prepend to all package imports (e.g., 'theater' for 'theater.movies.data_classes')
     """
     logger = logger or print
     data_model = _get_data_model(model_id, client, logger)
@@ -117,6 +121,7 @@ def generate_sdk(
         "inheritance",
         logger,
         config or PygenConfig(),
+        import_prefix,
     )
     sdk = sdk_generator.generate_sdk()
     if return_sdk_files:
@@ -136,6 +141,7 @@ def generate_sdk_notebook(
     default_instance_space: str | None = None,
     config: Optional[PygenConfig] = None,
     clean_pygen_temp_dir: bool = True,
+    import_prefix: Optional[str] = None,
 ) -> Any:
     """
     Generates a Python SDK tailored to the given Data Model(s) and imports it into the current Python session.
@@ -165,6 +171,7 @@ def generate_sdk_notebook(
         config: The configuration used to control how to generate the SDK.
         clean_pygen_temp_dir: Whether to clean the temporary directory used to store the generated SDK.
             Defaults to True.
+        import_prefix: prefix to prepend to all package imports (e.g., 'theater' for 'theater.movies.data_classes')
 
     Returns:
         The instantiated generated client class.
@@ -197,6 +204,7 @@ def generate_sdk_notebook(
         overwrite=True,
         format_code=False,
         config=config,
+        import_prefix=import_prefix,
     )
     if str(output_dir) not in sys.path:
         sys.path.append(str(output_dir))


### PR DESCRIPTION
## Description
I'd like to be able to specify an import prefix that is prepended to the import paths - this will allow the user to set an absolute import path. 

The behavior is similar to specifying a `top_level_package` with the exception that no additional folders are created.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
