### PR TITLE
[PYG-286] Fix not more warnings on core model.

### DIFF
--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -142,16 +142,17 @@ def _generate_sdk(
     if client_name is None:
         client_name = _default_client_name(external_id)
 
-    sdk_generator = SDKGenerator(
-        top_level_package,
-        client_name,
-        data_model,
-        default_instance_space,
-        "inheritance",
-        logger,
-        config or PygenConfig(),
-    )
     with warnings.catch_warnings(record=True) as warning_logger:
+        sdk_generator = SDKGenerator(
+            top_level_package,
+            client_name,
+            data_model,
+            default_instance_space,
+            "inheritance",
+            logger,
+            config or PygenConfig(),
+        )
+
         sdk = sdk_generator.generate_sdk()
     if warning_logger:
         print_warnings(warning_logger, logger, context)

--- a/cognite/pygen/_warnings.py
+++ b/cognite/pygen/_warnings.py
@@ -163,11 +163,18 @@ def _print_group(console: Callable[[str], None], group: type[PygenWarning], warn
         for view, properties in itertools.groupby(
             sorted(property_warnings, key=lambda w: w.view_id.external_id), key=lambda w: w.view_id.external_id
         ):
-            properties_str = ", ".join(warning.property_name for warning in properties)
-            console(
-                f"{indent}The following properties in view {view} will have an underscore "
-                f"added to avoid name collision: {properties_str}"
-            )
+            properties_list = list(properties)
+            if len(properties_list) == 1:
+                console(
+                    f"{indent} The property {properties_list[0].property_name!r} in view {view} "
+                    "will have an underscore to avoid name collision."
+                )
+            else:
+                properties_str = ", ".join(warning.property_name for warning in properties)
+                console(
+                    f"{indent}The following properties in view {view} will have an underscore "
+                    f"added to avoid name collision: {properties_str}"
+                )
     elif group is MissingReverseDirectRelationTargetWarning:
         relation_warnings = cast(list[MissingReverseDirectRelationTargetWarning], warning_list)
         for relation_warn in relation_warnings:


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
