### PR TITLE
👷Fix docs build, freeze mistune to 3.0.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,6 @@ mkdocs-gitbook==0.0.1
 mkdocs-glightbox==0.4.*
 pymdown-extensions==10.13.*
 mkdocstrings[python]==0.27.*
+# dependencies for mkdocstrings
+# 3.1.0 breaks nbconvert
+mistune==3.0.2


### PR DESCRIPTION
## Description

Can be removed when https://github.com/jupyter/nbconvert/issues/2198 is fixed.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
