### PR TITLE
[PYG-348]  🤕 fix: ensure output dir is a path

### DIFF
--- a/cognite/pygen/_generator.py
+++ b/cognite/pygen/_generator.py
@@ -163,6 +163,7 @@ def _generate_sdk(
     if return_sdk_files:
         return sdk
     output_dir = output_dir or (Path.cwd() / Path(top_level_package.replace(".", "/")))
+    output_dir = Path(output_dir)
     logger(f"Writing SDK to {output_dir}")
     write_sdk_to_disk(sdk, output_dir, overwrite, logger, format_code)
     logger("Done!")


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/pygen/blob/main/docs/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired (?), bump the version number by running `python dev.py bump --patch` (replace `--patch` with `--minor` or `--major` per [semantic versioning](https://semver.org/)).
- [ ] Regenerate example SDKs `export PYTHONPATH=. && python dev.py generate`. Need to be run both
  for `pydantic` `v1` and `v2` environments.
