### PR TITLE
[PYG-354] 🤳 feat: added enum option to filtering

### DIFF
--- a/cognite/pygen/_core/models/filter_methods.py
+++ b/cognite/pygen/_core/models/filter_methods.py
@@ -10,6 +10,7 @@ from cognite.client.data_classes import data_modeling as dm
 
 from cognite.pygen import config as pygen_config
 from cognite.pygen.config.reserved_words import is_reserved_word
+from cognite.pygen.utils.helper import _get_literal_str
 
 from .fields import (
     BaseConnectionField,
@@ -94,6 +95,8 @@ class FilterImplementation:
         elif self.filter is dm.filters.Equals:
             parameter = next(iter(self.keyword_arguments.values()))
             parameter_type = parameter.type_
+            if match := _get_literal_str(parameter_type):
+                parameter_type = parameter_type.replace(match, "str")
             if "|" in parameter_type:
                 parameter_type = parameter_type.split("|")[0].strip()
             return f"isinstance({parameter.name}, {parameter_type})"
@@ -157,7 +160,7 @@ class FilterImplementationOnetoOneEdge(FilterImplementation):
 
 @dataclass
 class FilterMethod:
-    """This classe represents a filter that can be used in any method that requires filtering.
+    """This class represents a filter that can be used in any method that requires filtering.
 
     Args:
         parameters: The parameters of the filter.

--- a/cognite/pygen/_core/templates/api_class_edge.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_edge.py.jinja
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 {% endif %}
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 {% if edge_api.has_edge_class %}

--- a/cognite/pygen/config/filtering_methods.py
+++ b/cognite/pygen/config/filtering_methods.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 
 from cognite.client import data_modeling as dm
+from cognite.client.data_classes.data_modeling.data_types import Enum
 
 
 @dataclass
@@ -51,6 +52,7 @@ class Filtering:
     date: tuple[type[dm.Filter], ...] = (dm.filters.Range,)
     datetime: tuple[type[dm.Filter], ...] = (dm.filters.Range,)
     string: tuple[type[dm.Filter], ...] = (dm.filters.Equals, dm.filters.In, dm.filters.Prefix)
+    enum: tuple[type[dm.Filter], ...] = (dm.filters.Equals, dm.filters.In)
     edge_one_to_one: tuple[type[dm.Filter], ...] = (dm.filters.Equals, dm.filters.In)
     by_name: dict[str, tuple[type[dm.Filter], ...]] = dataclass_field(
         default_factory=lambda: {"externalId": (dm.filters.Prefix,), "space": (dm.filters.Equals, dm.filters.In)}
@@ -72,6 +74,8 @@ class Filtering:
             return self.datetime
         elif isinstance(type_, dm.Text):
             return self.string
+        elif isinstance(type_, Enum):
+            return self.enum
         elif isinstance(type_, dm.DirectRelation):
             return self.edge_one_to_one
         else:

--- a/cognite/pygen/utils/helper.py
+++ b/cognite/pygen/utils/helper.py
@@ -21,3 +21,35 @@ def chdir(new_dir: Path) -> Iterator[None]:
 
     finally:
         os.chdir(current_working_dir)
+
+
+def _get_literal_str(text: str) -> str | None:
+    """Finds the Literal in a string and returns it.
+
+    Args:
+        text: The string to search for the Literal.
+
+    Returns:
+        The Literal in the string, or None if not found.
+
+    Examples:
+
+        >>> _get_literal_str("Literal['hello']")
+        "Literal['hello']"
+        >>> _get_literal_str("str | int")
+
+        >>> _get_literal_str("Literal['hello', 'world'] | int")
+        "Literal['hello', 'world']"
+        >>> _get_literal_str('None | Literal["hello", "world", "!"]')
+        'Literal["hello", "world", "!"]'
+    """
+    if "Literal[" not in text:
+        return None
+
+    start = text.find("Literal[")
+    end = text.find("]", start) + 1
+
+    if start == -1 or end == -1:
+        return None
+
+    return text[start:end]

--- a/cognite/pygen/utils/helper.py
+++ b/cognite/pygen/utils/helper.py
@@ -42,14 +42,16 @@ def _get_literal_str(text: str) -> str | None:
         "Literal['hello', 'world']"
         >>> _get_literal_str('None | Literal["hello", "world", "!"]')
         'Literal["hello", "world", "!"]'
+        >>> _get_literal_str('Literal["incomplete')
+
     """
     if "Literal[" not in text:
         return None
 
     start = text.find("Literal[")
-    end = text.find("]", start) + 1
+    end = text.find("]", start)
 
     if start == -1 or end == -1:
         return None
 
-    return text[start:end]
+    return text[start : end + 1]

--- a/examples/cognite_core/_api/cognite_360_image_collection.py
+++ b/examples/cognite_core/_api/cognite_360_image_collection.py
@@ -130,6 +130,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -149,6 +155,8 @@ class Cognite360ImageCollectionAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image collections to return. Defaults to 25.
@@ -183,6 +191,8 @@ class Cognite360ImageCollectionAPI(
             name,
             name_prefix,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -220,6 +230,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -249,6 +265,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -282,6 +304,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -314,6 +342,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -337,6 +371,8 @@ class Cognite360ImageCollectionAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image collections to return. Defaults to 25.
@@ -365,6 +401,8 @@ class Cognite360ImageCollectionAPI(
             name,
             name_prefix,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -400,6 +438,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -418,6 +462,8 @@ class Cognite360ImageCollectionAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image collections to return.
@@ -437,6 +483,8 @@ class Cognite360ImageCollectionAPI(
             name,
             name_prefix,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -498,6 +546,12 @@ class Cognite360ImageCollectionAPI(
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -516,6 +570,8 @@ class Cognite360ImageCollectionAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image collections to return.
@@ -551,6 +607,8 @@ class Cognite360ImageCollectionAPI(
             name,
             name_prefix,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_360_image_model.py
+++ b/examples/cognite_core/_api/cognite_360_image_model.py
@@ -123,6 +123,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -141,6 +142,7 @@ class Cognite360ImageModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image models to return. Defaults to 25.
@@ -174,6 +176,7 @@ class Cognite360ImageModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -208,6 +211,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -234,6 +238,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -264,6 +269,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -293,6 +299,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -315,6 +322,7 @@ class Cognite360ImageModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image models to return. Defaults to 25.
@@ -342,6 +350,7 @@ class Cognite360ImageModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -374,6 +383,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -391,6 +401,7 @@ class Cognite360ImageModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image models to return.
@@ -409,6 +420,7 @@ class Cognite360ImageModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -478,6 +490,7 @@ class Cognite360ImageModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -495,6 +508,7 @@ class Cognite360ImageModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 360 image models to return.
@@ -529,6 +543,7 @@ class Cognite360ImageModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_360_image_station.py
+++ b/examples/cognite_core/_api/cognite_360_image_station.py
@@ -106,6 +106,7 @@ class Cognite360ImageStationAPI(
         properties: Cognite360ImageStationTextFields | SequenceNotStr[Cognite360ImageStationTextFields] | None = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -123,6 +124,7 @@ class Cognite360ImageStationAPI(
             properties: The property to search, if nothing is passed all text fields will be searched.
             description: The description to filter on.
             description_prefix: The prefix of the description to filter on.
+            group_type: The group type to filter on.
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
@@ -155,6 +157,7 @@ class Cognite360ImageStationAPI(
             self._view_id,
             description,
             description_prefix,
+            group_type,
             name,
             name_prefix,
             external_id_prefix,
@@ -183,6 +186,7 @@ class Cognite360ImageStationAPI(
         ) = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -203,6 +207,7 @@ class Cognite360ImageStationAPI(
         ) = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -227,6 +232,7 @@ class Cognite360ImageStationAPI(
         ) = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -250,6 +256,7 @@ class Cognite360ImageStationAPI(
         ) = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -271,6 +278,7 @@ class Cognite360ImageStationAPI(
             search_property: The text field to search in.
             description: The description to filter on.
             description_prefix: The prefix of the description to filter on.
+            group_type: The group type to filter on.
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
@@ -297,6 +305,7 @@ class Cognite360ImageStationAPI(
             self._view_id,
             description,
             description_prefix,
+            group_type,
             name,
             name_prefix,
             external_id_prefix,
@@ -323,6 +332,7 @@ class Cognite360ImageStationAPI(
         ) = None,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -339,6 +349,7 @@ class Cognite360ImageStationAPI(
             search_property: The text field to search in.
             description: The description to filter on.
             description_prefix: The prefix of the description to filter on.
+            group_type: The group type to filter on.
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
@@ -356,6 +367,7 @@ class Cognite360ImageStationAPI(
             self._view_id,
             description,
             description_prefix,
+            group_type,
             name,
             name_prefix,
             external_id_prefix,
@@ -400,6 +412,7 @@ class Cognite360ImageStationAPI(
         self,
         description: str | list[str] | None = None,
         description_prefix: str | None = None,
+        group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
         name: str | list[str] | None = None,
         name_prefix: str | None = None,
         external_id_prefix: str | None = None,
@@ -415,6 +428,7 @@ class Cognite360ImageStationAPI(
         Args:
             description: The description to filter on.
             description_prefix: The prefix of the description to filter on.
+            group_type: The group type to filter on.
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
@@ -445,6 +459,7 @@ class Cognite360ImageStationAPI(
             self._view_id,
             description,
             description_prefix,
+            group_type,
             name,
             name_prefix,
             external_id_prefix,

--- a/examples/cognite_core/_api/cognite_3_d_model.py
+++ b/examples/cognite_core/_api/cognite_3_d_model.py
@@ -138,6 +138,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -156,6 +157,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D models to return. Defaults to 25.
@@ -189,6 +191,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -223,6 +226,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -249,6 +253,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -279,6 +284,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -308,6 +314,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -330,6 +337,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D models to return. Defaults to 25.
@@ -357,6 +365,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -389,6 +398,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -406,6 +416,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D models to return.
@@ -424,6 +435,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -484,6 +496,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -501,6 +514,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D models to return.
@@ -535,6 +549,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_3_d_object_images_360.py
+++ b/examples/cognite_core/_api/cognite_3_d_object_images_360.py
@@ -56,6 +56,9 @@ class Cognite3DObjectImages360API(EdgePropertyAPI):
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        status: (
+            Literal["Approved", "Rejected", "Suggested"] | list[Literal["Approved", "Rejected", "Suggested"]] | None
+        ) = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit=DEFAULT_LIMIT_READ,
@@ -88,6 +91,7 @@ class Cognite3DObjectImages360API(EdgePropertyAPI):
             max_source_updated_time: The maximum value of the source updated time to filter on.
             source_updated_user: The source updated user to filter on.
             source_updated_user_prefix: The prefix of the source updated user to filter on.
+            status: The status to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of images 360 edges to return. Defaults to 25.
@@ -135,6 +139,7 @@ class Cognite3DObjectImages360API(EdgePropertyAPI):
             max_source_updated_time,
             source_updated_user,
             source_updated_user_prefix,
+            status,
             external_id_prefix,
             space,
         )

--- a/examples/cognite_core/_api/cognite_3_d_object_images_360.py
+++ b/examples/cognite_core/_api/cognite_3_d_object_images_360.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from cognite_core.data_classes import (

--- a/examples/cognite_core/_api/cognite_3_d_revision.py
+++ b/examples/cognite_core/_api/cognite_3_d_revision.py
@@ -140,6 +140,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -155,6 +161,8 @@ class Cognite3DRevisionAPI(
             properties: The property to search, if nothing is passed all text fields will be searched.
             model_3d: The model 3d to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D revisions to return. Defaults to 25.
@@ -185,6 +193,8 @@ class Cognite3DRevisionAPI(
             self._view_id,
             model_3d,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -214,6 +224,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -235,6 +251,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -260,6 +282,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -284,6 +312,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -301,6 +335,8 @@ class Cognite3DRevisionAPI(
             property: The property to perform aggregation on.
             model_3d: The model 3d to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D revisions to return. Defaults to 25.
@@ -325,6 +361,8 @@ class Cognite3DRevisionAPI(
             self._view_id,
             model_3d,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -352,6 +390,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -364,6 +408,8 @@ class Cognite3DRevisionAPI(
             interval: The interval to use for the histogram bins.
             model_3d: The model 3d to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D revisions to return.
@@ -379,6 +425,8 @@ class Cognite3DRevisionAPI(
             self._view_id,
             model_3d,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -436,6 +484,12 @@ class Cognite3DRevisionAPI(
             | None
         ) = None,
         published: bool | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -450,6 +504,8 @@ class Cognite3DRevisionAPI(
         Args:
             model_3d: The model 3d to filter on.
             published: The published to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite 3D revisions to return.
@@ -481,6 +537,8 @@ class Cognite3DRevisionAPI(
             self._view_id,
             model_3d,
             published,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_cad_model.py
+++ b/examples/cognite_core/_api/cognite_cad_model.py
@@ -121,6 +121,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -139,6 +140,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad models to return. Defaults to 25.
@@ -172,6 +174,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -206,6 +209,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -232,6 +236,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -262,6 +267,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -291,6 +297,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -313,6 +320,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad models to return. Defaults to 25.
@@ -340,6 +348,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -372,6 +381,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -389,6 +399,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad models to return.
@@ -407,6 +418,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -476,6 +488,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -493,6 +506,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad models to return.
@@ -527,6 +541,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_cad_revision.py
+++ b/examples/cognite_core/_api/cognite_cad_revision.py
@@ -121,6 +121,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -138,6 +144,8 @@ class CogniteCADRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad revisions to return. Defaults to 25.
@@ -170,6 +178,8 @@ class CogniteCADRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -201,6 +211,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -224,6 +240,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -251,6 +273,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -277,6 +305,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -296,6 +330,8 @@ class CogniteCADRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad revisions to return. Defaults to 25.
@@ -322,6 +358,8 @@ class CogniteCADRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -351,6 +389,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -365,6 +409,8 @@ class CogniteCADRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad revisions to return.
@@ -382,6 +428,8 @@ class CogniteCADRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -441,6 +489,12 @@ class CogniteCADRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -457,6 +511,8 @@ class CogniteCADRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite cad revisions to return.
@@ -490,6 +546,8 @@ class CogniteCADRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_point_cloud_model.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_model.py
@@ -125,6 +125,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -143,6 +144,7 @@ class CognitePointCloudModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud models to return. Defaults to 25.
@@ -176,6 +178,7 @@ class CognitePointCloudModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -212,6 +215,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -240,6 +244,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -272,6 +277,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -303,6 +309,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -325,6 +332,7 @@ class CognitePointCloudModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud models to return. Defaults to 25.
@@ -352,6 +360,7 @@ class CognitePointCloudModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -386,6 +395,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -403,6 +413,7 @@ class CognitePointCloudModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud models to return.
@@ -421,6 +432,7 @@ class CognitePointCloudModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -490,6 +502,7 @@ class CognitePointCloudModelAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -507,6 +520,7 @@ class CognitePointCloudModelAPI(
             name: The name to filter on.
             name_prefix: The prefix of the name to filter on.
             thumbnail: The thumbnail to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud models to return.
@@ -541,6 +555,7 @@ class CognitePointCloudModelAPI(
             name,
             name_prefix,
             thumbnail,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_point_cloud_revision.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_revision.py
@@ -128,6 +128,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -145,6 +151,8 @@ class CognitePointCloudRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud revisions to return. Defaults to 25.
@@ -177,6 +185,8 @@ class CognitePointCloudRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -208,6 +218,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -231,6 +247,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -258,6 +280,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -284,6 +312,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -303,6 +337,8 @@ class CognitePointCloudRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud revisions to return. Defaults to 25.
@@ -329,6 +365,8 @@ class CognitePointCloudRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -358,6 +396,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -372,6 +416,8 @@ class CognitePointCloudRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud revisions to return.
@@ -389,6 +435,8 @@ class CognitePointCloudRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -448,6 +496,12 @@ class CognitePointCloudRevisionAPI(
         published: bool | None = None,
         min_revision_id: int | None = None,
         max_revision_id: int | None = None,
+        status: (
+            Literal["Done", "Failed", "Processing", "Queued"]
+            | list[Literal["Done", "Failed", "Processing", "Queued"]]
+            | None
+        ) = None,
+        type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -464,6 +518,8 @@ class CognitePointCloudRevisionAPI(
             published: The published to filter on.
             min_revision_id: The minimum value of the revision id to filter on.
             max_revision_id: The maximum value of the revision id to filter on.
+            status: The status to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud revisions to return.
@@ -497,6 +553,8 @@ class CognitePointCloudRevisionAPI(
             published,
             min_revision_id,
             max_revision_id,
+            status,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_point_cloud_volume.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_volume.py
@@ -147,6 +147,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -169,6 +170,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix: The prefix of the name to filter on.
             object_3d: The object 3d to filter on.
             revisions: The revision to filter on.
+            volume_type: The volume type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud volumes to return. Defaults to 25.
@@ -206,6 +208,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix,
             object_3d,
             revisions,
+            volume_type,
             external_id_prefix,
             space,
             filter,
@@ -260,6 +263,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -306,6 +310,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -356,6 +361,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -405,6 +411,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -431,6 +438,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix: The prefix of the name to filter on.
             object_3d: The object 3d to filter on.
             revisions: The revision to filter on.
+            volume_type: The volume type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud volumes to return. Defaults to 25.
@@ -462,6 +470,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix,
             object_3d,
             revisions,
+            volume_type,
             external_id_prefix,
             space,
             filter,
@@ -514,6 +523,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -535,6 +545,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix: The prefix of the name to filter on.
             object_3d: The object 3d to filter on.
             revisions: The revision to filter on.
+            volume_type: The volume type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud volumes to return.
@@ -557,6 +568,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix,
             object_3d,
             revisions,
+            volume_type,
             external_id_prefix,
             space,
             filter,
@@ -649,6 +661,7 @@ class CognitePointCloudVolumeAPI(
             | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
             | None
         ) = None,
+        volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -670,6 +683,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix: The prefix of the name to filter on.
             object_3d: The object 3d to filter on.
             revisions: The revision to filter on.
+            volume_type: The volume type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of Cognite point cloud volumes to return.
@@ -708,6 +722,7 @@ class CognitePointCloudVolumeAPI(
             name_prefix,
             object_3d,
             revisions,
+            volume_type,
             external_id_prefix,
             space,
             filter,

--- a/examples/cognite_core/_api/cognite_time_series.py
+++ b/examples/cognite_core/_api/cognite_time_series.py
@@ -158,6 +158,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -201,6 +202,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time: The maximum value of the source updated time to filter on.
             source_updated_user: The source updated user to filter on.
             source_updated_user_prefix: The prefix of the source updated user to filter on.
+            type_: The type to filter on.
             unit: The unit to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
@@ -252,6 +254,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time,
             source_updated_user,
             source_updated_user_prefix,
+            type_,
             unit,
             external_id_prefix,
             space,
@@ -318,6 +321,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -383,6 +387,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -452,6 +457,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -520,6 +526,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -567,6 +574,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time: The maximum value of the source updated time to filter on.
             source_updated_user: The source updated user to filter on.
             source_updated_user_prefix: The prefix of the source updated user to filter on.
+            type_: The type to filter on.
             unit: The unit to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
@@ -612,6 +620,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time,
             source_updated_user,
             source_updated_user_prefix,
+            type_,
             unit,
             external_id_prefix,
             space,
@@ -676,6 +685,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -718,6 +728,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time: The maximum value of the source updated time to filter on.
             source_updated_user: The source updated user to filter on.
             source_updated_user_prefix: The prefix of the source updated user to filter on.
+            type_: The type to filter on.
             unit: The unit to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
@@ -754,6 +765,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time,
             source_updated_user,
             source_updated_user_prefix,
+            type_,
             unit,
             external_id_prefix,
             space,
@@ -876,6 +888,7 @@ class CogniteTimeSeriesAPI(
         max_source_updated_time: datetime.datetime | None = None,
         source_updated_user: str | list[str] | None = None,
         source_updated_user_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         unit: (
             str
             | tuple[str, str]
@@ -918,6 +931,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time: The maximum value of the source updated time to filter on.
             source_updated_user: The source updated user to filter on.
             source_updated_user_prefix: The prefix of the source updated user to filter on.
+            type_: The type to filter on.
             unit: The unit to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
@@ -970,6 +984,7 @@ class CogniteTimeSeriesAPI(
             max_source_updated_time,
             source_updated_user,
             source_updated_user_prefix,
+            type_,
             unit,
             external_id_prefix,
             space,

--- a/examples/cognite_core/data_classes/_cognite_360_image_annotation.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_annotation.py
@@ -338,6 +338,9 @@ def _create_cognite_360_image_annotation_filter(
     max_source_updated_time: datetime.datetime | None = None,
     source_updated_user: str | list[str] | None = None,
     source_updated_user_prefix: str | None = None,
+    status: (
+        Literal["Approved", "Rejected", "Suggested"] | list[Literal["Approved", "Rejected", "Suggested"]] | None
+    ) = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -462,6 +465,10 @@ def _create_cognite_360_image_annotation_filter(
         filters.append(
             dm.filters.Prefix(view_id.as_property_ref("sourceUpdatedUser"), value=source_updated_user_prefix)
         )
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["edge", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_360_image_collection.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_collection.py
@@ -251,6 +251,12 @@ def _create_cognite_360_image_collection_filter(
     name: str | list[str] | None = None,
     name_prefix: str | None = None,
     published: bool | None = None,
+    status: (
+        Literal["Done", "Failed", "Processing", "Queued"]
+        | list[Literal["Done", "Failed", "Processing", "Queued"]]
+        | None
+    ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -276,6 +282,14 @@ def _create_cognite_360_image_collection_filter(
         filters.append(dm.filters.Prefix(view_id.as_property_ref("name"), value=name_prefix))
     if isinstance(published, bool):
         filters.append(dm.filters.Equals(view_id.as_property_ref("published"), value=published))
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_360_image_model.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_model.py
@@ -263,6 +263,7 @@ def _create_cognite_360_image_model_filter(
         | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
         | None
     ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -288,6 +289,10 @@ def _create_cognite_360_image_model_filter(
                 view_id.as_property_ref("thumbnail"), values=[as_instance_dict_id(item) for item in thumbnail]
             )
         )
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_360_image_station.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_station.py
@@ -181,6 +181,7 @@ def _create_cognite_360_image_station_filter(
     view_id: dm.ViewId,
     description: str | list[str] | None = None,
     description_prefix: str | None = None,
+    group_type: Literal["Station360"] | list[Literal["Station360"]] | None = None,
     name: str | list[str] | None = None,
     name_prefix: str | None = None,
     external_id_prefix: str | None = None,
@@ -194,6 +195,10 @@ def _create_cognite_360_image_station_filter(
         filters.append(dm.filters.In(view_id.as_property_ref("description"), values=description))
     if description_prefix is not None:
         filters.append(dm.filters.Prefix(view_id.as_property_ref("description"), value=description_prefix))
+    if isinstance(group_type, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("groupType"), value=group_type))
+    if group_type and isinstance(group_type, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("groupType"), values=group_type))
     if isinstance(name, str):
         filters.append(dm.filters.Equals(view_id.as_property_ref("name"), value=name))
     if name and isinstance(name, list):

--- a/examples/cognite_core/data_classes/_cognite_3_d_model.py
+++ b/examples/cognite_core/data_classes/_cognite_3_d_model.py
@@ -246,6 +246,7 @@ def _create_cognite_3_d_model_filter(
         | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
         | None
     ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -271,6 +272,10 @@ def _create_cognite_3_d_model_filter(
                 view_id.as_property_ref("thumbnail"), values=[as_instance_dict_id(item) for item in thumbnail]
             )
         )
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_3_d_revision.py
+++ b/examples/cognite_core/data_classes/_cognite_3_d_revision.py
@@ -236,6 +236,12 @@ def _create_cognite_3_d_revision_filter(
         | None
     ) = None,
     published: bool | None = None,
+    status: (
+        Literal["Done", "Failed", "Processing", "Queued"]
+        | list[Literal["Done", "Failed", "Processing", "Queued"]]
+        | None
+    ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -249,6 +255,14 @@ def _create_cognite_3_d_revision_filter(
         )
     if isinstance(published, bool):
         filters.append(dm.filters.Equals(view_id.as_property_ref("published"), value=published))
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_annotation.py
+++ b/examples/cognite_core/data_classes/_cognite_annotation.py
@@ -313,6 +313,9 @@ def _create_cognite_annotation_filter(
     max_source_updated_time: datetime.datetime | None = None,
     source_updated_user: str | list[str] | None = None,
     source_updated_user_prefix: str | None = None,
+    status: (
+        Literal["Approved", "Rejected", "Suggested"] | list[Literal["Approved", "Rejected", "Suggested"]] | None
+    ) = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -431,6 +434,10 @@ def _create_cognite_annotation_filter(
         filters.append(
             dm.filters.Prefix(view_id.as_property_ref("sourceUpdatedUser"), value=source_updated_user_prefix)
         )
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["edge", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_cad_model.py
+++ b/examples/cognite_core/data_classes/_cognite_cad_model.py
@@ -258,6 +258,7 @@ def _create_cognite_cad_model_filter(
         | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
         | None
     ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -283,6 +284,10 @@ def _create_cognite_cad_model_filter(
                 view_id.as_property_ref("thumbnail"), values=[as_instance_dict_id(item) for item in thumbnail]
             )
         )
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_cad_revision.py
+++ b/examples/cognite_core/data_classes/_cognite_cad_revision.py
@@ -228,6 +228,12 @@ def _create_cognite_cad_revision_filter(
     published: bool | None = None,
     min_revision_id: int | None = None,
     max_revision_id: int | None = None,
+    status: (
+        Literal["Done", "Failed", "Processing", "Queued"]
+        | list[Literal["Done", "Failed", "Processing", "Queued"]]
+        | None
+    ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -245,6 +251,14 @@ def _create_cognite_cad_revision_filter(
         filters.append(
             dm.filters.Range(view_id.as_property_ref("revisionId"), gte=min_revision_id, lte=max_revision_id)
         )
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_diagram_annotation.py
+++ b/examples/cognite_core/data_classes/_cognite_diagram_annotation.py
@@ -476,6 +476,9 @@ def _create_cognite_diagram_annotation_filter(
     max_start_node_y_max: float | None = None,
     min_start_node_y_min: float | None = None,
     max_start_node_y_min: float | None = None,
+    status: (
+        Literal["Approved", "Rejected", "Suggested"] | list[Literal["Approved", "Rejected", "Suggested"]] | None
+    ) = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -660,6 +663,10 @@ def _create_cognite_diagram_annotation_filter(
                 view_id.as_property_ref("startNodeYMin"), gte=min_start_node_y_min, lte=max_start_node_y_min
             )
         )
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["edge", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_point_cloud_model.py
+++ b/examples/cognite_core/data_classes/_cognite_point_cloud_model.py
@@ -263,6 +263,7 @@ def _create_cognite_point_cloud_model_filter(
         | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
         | None
     ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -288,6 +289,10 @@ def _create_cognite_point_cloud_model_filter(
                 view_id.as_property_ref("thumbnail"), values=[as_instance_dict_id(item) for item in thumbnail]
             )
         )
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_point_cloud_revision.py
+++ b/examples/cognite_core/data_classes/_cognite_point_cloud_revision.py
@@ -230,6 +230,12 @@ def _create_cognite_point_cloud_revision_filter(
     published: bool | None = None,
     min_revision_id: int | None = None,
     max_revision_id: int | None = None,
+    status: (
+        Literal["Done", "Failed", "Processing", "Queued"]
+        | list[Literal["Done", "Failed", "Processing", "Queued"]]
+        | None
+    ) = None,
+    type_: Literal["CAD", "Image360", "PointCloud"] | list[Literal["CAD", "Image360", "PointCloud"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -247,6 +253,14 @@ def _create_cognite_point_cloud_revision_filter(
         filters.append(
             dm.filters.Range(view_id.as_property_ref("revisionId"), gte=min_revision_id, lte=max_revision_id)
         )
+    if isinstance(status, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("status"), value=status))
+    if status and isinstance(status, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("status"), values=status))
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_point_cloud_volume.py
+++ b/examples/cognite_core/data_classes/_cognite_point_cloud_volume.py
@@ -374,6 +374,7 @@ def _create_cognite_point_cloud_volume_filter(
         | Sequence[str | tuple[str, str] | dm.NodeId | dm.DirectRelationReference]
         | None
     ) = None,
+    volume_type: Literal["Box", "Cylinder"] | list[Literal["Box", "Cylinder"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -417,6 +418,10 @@ def _create_cognite_point_cloud_volume_filter(
                 view_id.as_property_ref("revisions"), values=[as_instance_dict_id(item) for item in revisions]
             )
         )
+    if isinstance(volume_type, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("volumeType"), value=volume_type))
+    if volume_type and isinstance(volume_type, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("volumeType"), values=volume_type))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/examples/cognite_core/data_classes/_cognite_time_series.py
+++ b/examples/cognite_core/data_classes/_cognite_time_series.py
@@ -486,6 +486,7 @@ def _create_cognite_time_series_filter(
     max_source_updated_time: datetime.datetime | None = None,
     source_updated_user: str | list[str] | None = None,
     source_updated_user_prefix: str | None = None,
+    type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
     unit: (
         str
         | tuple[str, str]
@@ -583,6 +584,10 @@ def _create_cognite_time_series_filter(
         filters.append(
             dm.filters.Prefix(view_id.as_property_ref("sourceUpdatedUser"), value=source_updated_user_prefix)
         )
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if isinstance(unit, str | dm.NodeId | dm.DirectRelationReference) or is_tuple_id(unit):
         filters.append(dm.filters.Equals(view_id.as_property_ref("unit"), value=as_instance_dict_id(unit)))
     if unit and isinstance(unit, Sequence) and not isinstance(unit, str) and not is_tuple_id(unit):

--- a/examples/omni/_api/connection_item_a_outwards.py
+++ b/examples/omni/_api/connection_item_a_outwards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_b_inwards.py
+++ b/examples/omni/_api/connection_item_b_inwards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_b_self_edge.py
+++ b/examples/omni/_api/connection_item_b_self_edge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_c_node_connection_item_a.py
+++ b/examples/omni/_api/connection_item_c_node_connection_item_a.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_c_node_connection_item_b.py
+++ b/examples/omni/_api/connection_item_c_node_connection_item_b.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_d_outwards_single.py
+++ b/examples/omni/_api/connection_item_d_outwards_single.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_e_inwards_single.py
+++ b/examples/omni/_api/connection_item_e_inwards_single.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni/_api/connection_item_e_inwards_single_property.py
+++ b/examples/omni/_api/connection_item_e_inwards_single_property.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni.data_classes import (

--- a/examples/omni/_api/connection_item_f_outwards_multi.py
+++ b/examples/omni/_api/connection_item_f_outwards_multi.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni.data_classes import (

--- a/examples/omni/_api/connection_item_f_outwards_single.py
+++ b/examples/omni/_api/connection_item_f_outwards_single.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni.data_classes import (

--- a/examples/omni/_api/connection_item_g_inwards_multi_property.py
+++ b/examples/omni/_api/connection_item_g_inwards_multi_property.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni.data_classes import (

--- a/examples/omni/_api/dependent_on_non_writable_to_non_writable.py
+++ b/examples/omni/_api/dependent_on_non_writable_to_non_writable.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni_sub/_api/connection_item_a_outwards.py
+++ b/examples/omni_sub/_api/connection_item_a_outwards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni_sub._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni_sub/_api/connection_item_b_inwards.py
+++ b/examples/omni_sub/_api/connection_item_b_inwards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni_sub._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni_sub/_api/connection_item_b_self_edge.py
+++ b/examples/omni_sub/_api/connection_item_b_self_edge.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni_sub._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni_sub/_api/connection_item_c_node_connection_item_a.py
+++ b/examples/omni_sub/_api/connection_item_c_node_connection_item_a.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni_sub._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/omni_sub/_api/connection_item_c_node_connection_item_b.py
+++ b/examples/omni_sub/_api/connection_item_c_node_connection_item_b.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from omni_sub._api._core import DEFAULT_LIMIT_READ, EdgeAPI, _create_edge_filter

--- a/examples/wind_turbine/_api/metmast_wind_turbines.py
+++ b/examples/wind_turbine/_api/metmast_wind_turbines.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from wind_turbine.data_classes import (

--- a/examples/wind_turbine/_api/sensor_time_series.py
+++ b/examples/wind_turbine/_api/sensor_time_series.py
@@ -113,6 +113,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -137,6 +138,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix: The prefix of the source unit to filter on.
             standard_name: The standard name to filter on.
             standard_name_prefix: The prefix of the standard name to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of sensor time series to return. Defaults to 25.
@@ -176,6 +178,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix,
             standard_name,
             standard_name_prefix,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -209,6 +212,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -234,6 +238,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -263,6 +268,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -291,6 +297,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -319,6 +326,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix: The prefix of the source unit to filter on.
             standard_name: The standard name to filter on.
             standard_name_prefix: The prefix of the standard name to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of sensor time series to return. Defaults to 25.
@@ -352,6 +360,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix,
             standard_name,
             standard_name_prefix,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -383,6 +392,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -406,6 +416,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix: The prefix of the source unit to filter on.
             standard_name: The standard name to filter on.
             standard_name_prefix: The prefix of the standard name to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of sensor time series to return.
@@ -430,6 +441,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix,
             standard_name,
             standard_name_prefix,
+            type_,
             external_id_prefix,
             space,
             filter,
@@ -481,6 +493,7 @@ class SensorTimeSeriesAPI(
         source_unit_prefix: str | None = None,
         standard_name: str | list[str] | None = None,
         standard_name_prefix: str | None = None,
+        type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -503,6 +516,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix: The prefix of the source unit to filter on.
             standard_name: The standard name to filter on.
             standard_name_prefix: The prefix of the standard name to filter on.
+            type_: The type to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of sensor time series to return.
@@ -540,6 +554,7 @@ class SensorTimeSeriesAPI(
             source_unit_prefix,
             standard_name,
             standard_name_prefix,
+            type_,
             external_id_prefix,
             space,
             filter,

--- a/examples/wind_turbine/_api/wind_turbine_metmast.py
+++ b/examples/wind_turbine/_api/wind_turbine_metmast.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-
+from typing import Literal
 from cognite.client import data_modeling as dm
 
 from wind_turbine.data_classes import (

--- a/examples/wind_turbine/data_classes/_sensor_time_series.py
+++ b/examples/wind_turbine/data_classes/_sensor_time_series.py
@@ -229,6 +229,7 @@ def _create_sensor_time_series_filter(
     source_unit_prefix: str | None = None,
     standard_name: str | list[str] | None = None,
     standard_name_prefix: str | None = None,
+    type_: Literal["numeric", "string"] | list[Literal["numeric", "string"]] | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -266,6 +267,10 @@ def _create_sensor_time_series_filter(
         filters.append(dm.filters.In(view_id.as_property_ref("standardName"), values=standard_name))
     if standard_name_prefix is not None:
         filters.append(dm.filters.Prefix(view_id.as_property_ref("standardName"), value=standard_name_prefix))
+    if isinstance(type_, str):
+        filters.append(dm.filters.Equals(view_id.as_property_ref("type"), value=type_))
+    if type_ and isinstance(type_, list):
+        filters.append(dm.filters.In(view_id.as_property_ref("type"), values=type_))
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):

--- a/tests/test_integration/test_list.py
+++ b/tests/test_integration/test_list.py
@@ -196,3 +196,11 @@ def test_list_with_reversed_direct_relation_of_list(omni_client: OmniClient) -> 
     assert reverse_direct_relations, f"Missing reverse_direct_single: {reverse_direct_relations}"
     df = items.to_pandas()
     assert isinstance(df, pd.DataFrame)
+
+
+def test_list_filter_on_enum(turbine_client: WindTurbineClient) -> None:
+    items = turbine_client.sensor_time_series.list(type_="numeric", limit=5)
+
+    assert len(items) > 0
+    non_numeric = [item for item in items if item.type_ != "numeric"]
+    assert not non_numeric, f"Found items with type_ != 'numeric': {non_numeric}"


### PR DESCRIPTION
# Description

Support for filtering on enum properites.

**Reviewer Notes**
* Tried to have a clean history as most of the code lines are generated.
* All code inside the `examples/` directory is generated. 
* This PR is ~40 lines code, ~10 lines test and the rest is generated code.

## Bump

- [ ] Patch
- [x] Minor
- [ ] Skip

## Changelog
### Added

- The generated SDK now will create filter options for enums, for example, if you create an SDK for the `CogniteCore` model, you can now filter on `.list(type_="numeric")` to only get numeric timeseries.
