### PR TITLE
[PYG-362] 🤔Property edge with reverse direct relation property.

### DIFF
--- a/cognite/pygen/_core/templates/data_class_edge.py.jinja
+++ b/cognite/pygen/_core/templates/data_class_edge.py.jinja
@@ -329,8 +329,8 @@ class _{{ data_class.query_cls_name }}(EdgeQueryCore[T_DomainList, {{ data_class
             )
 
         {% for field in data_class.fields_of_type(ft.BaseConnectionField) %}
-        {% if not field.is_no_source_direct_relation %}
-        if _{{ field.destination_class.query_cls_name }} not in created_types:
+        {% if not field.is_direct_relation_no_source %}
+        if _{{ field.linked_class.query_cls_name }} not in created_types:
             self.{{ field.name }} = _{{ field.destination_class.query_cls_name }}(
                 created_types.copy(),
                 self._creation_path,
@@ -343,7 +343,7 @@ class _{{ data_class.query_cls_name }}(EdgeQueryCore[T_DomainList, {{ data_class
                 ),
                 {% elif field.is_reverse_direct_relation %}
                 dm.query.NodeResultSetExpression(
-                    through={{ field.reverse_property.data_class.view_id_str }}.as_property_ref("{{ field.prop_name }}"),
+                    through={{ field.through_str }},
                     direction="inwards",
                 ),
                 {% else %}

--- a/tests/test_unit/test_api/test_generate_sdk.py
+++ b/tests/test_unit/test_api/test_generate_sdk.py
@@ -182,6 +182,23 @@ class TestGenerateSDK:
             module = vars(importlib.import_module(top_level_package))
             assert client_name in module
 
+    def test_generate_sdk_with_edge_view_with_reverse_direct_relation(self, tmp_path: Path) -> None:
+        top_level_package = "reverse_direct_relation_model"
+        client_name = "ReverseDirectRelationClient"
+
+        generate_sdk(
+            DATA_MODEL_REVERSE_DIRECT_RELATION_IN_EDGE_VIEW,
+            top_level_package=top_level_package,
+            output_dir=tmp_path / top_level_package,
+            overwrite=True,
+            client_name=client_name,
+            default_instance_space="the_instance_space",
+        )
+
+        with append_to_sys_path(str(tmp_path)):
+            module = vars(importlib.import_module(top_level_package))
+            assert client_name in module
+
 
 DATA_MODEL_WITH_VIEW_PROPERTY_OF_TYPE_FIELD: dm.DataModel = dm.DataModel.load(
     {
@@ -678,6 +695,90 @@ DATA_MODEL_REVERSE_DIRECT_RELATION_THROUGH_CONTAINER = dm.DataModel(
             created_time=0,
             used_for="node",
             implements=None,
+            writable=True,
+            filter=None,
+        ),
+    ],
+)
+
+DATA_MODEL_REVERSE_DIRECT_RELATION_IN_EDGE_VIEW = dm.DataModel(
+    space="my_space",
+    external_id="MyModel",
+    version="1",
+    is_global=False,
+    last_updated_time=0,
+    created_time=0,
+    description=None,
+    name=None,
+    views=[
+        dm.View(
+            space="my_space",
+            external_id="WellboreMudRelationship",
+            version="1",
+            implements=[],
+            properties={
+                "muds": dm.MultiReverseDirectRelation(
+                    source=dm.ViewId("my_space", "Mud", "1"),
+                    through=dm.PropertyId(
+                        source=dm.ViewId("my_space", "Mud", "1"),
+                        property="wellbore",
+                    ),
+                )
+            },
+            used_for="all",
+            writable=False,
+            filter=None,
+            is_global=False,
+            last_updated_time=0,
+            created_time=0,
+            name=None,
+            description=None,
+        ),
+        dm.View(
+            space="my_space",
+            name="Mud",
+            external_id="Mud",
+            version="1",
+            properties={
+                "wellbore": dm.MappedProperty(
+                    container=dm.ContainerId("my_space", "MudContainer"),
+                    container_property_identifier="wellbore",
+                    type=dm.DirectRelation(),
+                    nullable=True,
+                    auto_increment=False,
+                    immutable=False,
+                    source=dm.ViewId("my_space", "Wellbore", "1"),
+                ),
+            },
+            description=None,
+            is_global=False,
+            last_updated_time=0,
+            created_time=0,
+            used_for="node",
+            implements=None,
+            writable=True,
+            filter=None,
+        ),
+        dm.View(
+            space="my_space",
+            name="Wellbore",
+            external_id="Wellbore",
+            version="1",
+            implements=[dm.ViewId("my_space", "WellboreMudRelationship", "1")],
+            properties={
+                "muds": dm.MultiReverseDirectRelation(
+                    source=dm.ViewId("my_space", "Mud", "1"),
+                    through=dm.PropertyId(
+                        source=dm.ViewId("my_space", "Mud", "1"),
+                        property="wellbore",
+                    ),
+                )
+            },
+            description=None,
+            is_global=False,
+            last_updated_time=0,
+            created_time=0,
+            used_for="node",
             writable=True,
             filter=None,
         ),


### PR DESCRIPTION
# Description

## Reviewer: This is a +-3 line fix, the rest being test data along with a test.

## User error message:
![image](https://github.com/user-attachments/assets/7a25d886-a88e-4e74-b03f-8fa205810b52)


## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Generating an SDK no longer raises a `jinja2.exceptions.UndefinedError` if the data model contains a view that is `used_for=edge/all` and contains a reverse direct relation property.
