### PR TITLE
[PYG-364] 🌴 Pagination cursor part 1

### DIFF
--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -433,6 +433,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -442,6 +443,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
             sort=sort,
             {% endif %}
             limit=limit,
+            max_retrieve_batch_limit=chunk_size,
             {% if data_class.has_container_fields %}
             has_container_fields=True,
             {% else %}

--- a/cognite/pygen/_core/templates/api_core.py.jinja
+++ b/cognite/pygen/_core/templates/api_core.py.jinja
@@ -181,6 +181,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -207,15 +208,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/cognite/pygen/_query/executor.py
+++ b/cognite/pygen/_query/executor.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes.aggregations import Count
 from cognite.client.exceptions import CogniteAPIError
 
 from cognite.pygen._query.constants import (
-    ACTUAL_INSTANCE_QUERY_LIMIT,
     IN_FILTER_CHUNK_SIZE,
     INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
@@ -68,7 +67,7 @@ class PaginationStatus:
     is_unlimited: bool
     max_retrieve_limit: int
     is_queryable: bool
-    max_retrieve_batch_limit = ACTUAL_INSTANCE_QUERY_LIMIT
+    max_retrieve_batch_limit: int = INSTANCE_QUERY_LIMIT
     cursor: str | None = None
     total_retrieved: int = 0
     last_batch_count: int = 0
@@ -119,7 +118,13 @@ class QueryExecutor:
         self._to_search = to_search
         self._temp_select = temp_select
         self._status_by_name = {
-            step.name: PaginationStatus(step.is_unlimited, step.max_retrieve_limit, step.is_queryable) for step in steps
+            step.name: PaginationStatus(
+                step.is_unlimited,
+                step.max_retrieve_limit,
+                step.is_queryable,
+                max_retrieve_batch_limit=step.max_retrieve_batch_limit,
+            )
+            for step in steps
         }
 
     def execute_query(

--- a/cognite/pygen/_query/executor.py
+++ b/cognite/pygen/_query/executor.py
@@ -11,6 +11,7 @@ from cognite.client.exceptions import CogniteAPIError
 
 from cognite.pygen._query.constants import (
     IN_FILTER_CHUNK_SIZE,
+    INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
     PRINT_PROGRESS_PER_N_NODES,
     SEARCH_LIMIT,

--- a/cognite/pygen/_query/executor.py
+++ b/cognite/pygen/_query/executor.py
@@ -163,13 +163,13 @@ class QueryExecutor:
                 if e.code == 408:
                     # Too big query, try to reduce the limit
                     if self._reduce_max_batch_limit():
+                        new_limit = status.max_retrieve_batch_limit
+                        warnings.warn(
+                            f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
+                            QueryReducingBatchSize,
+                            stacklevel=2,
+                        )
                         continue
-                    new_limit = status.max_retrieve_batch_limit
-                    warnings.warn(
-                        f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
-                        QueryReducingBatchSize,
-                        stacklevel=2,
-                    )
 
                 raise e
 

--- a/cognite/pygen/_query/executor.py
+++ b/cognite/pygen/_query/executor.py
@@ -11,7 +11,6 @@ from cognite.client.exceptions import CogniteAPIError
 
 from cognite.pygen._query.constants import (
     IN_FILTER_CHUNK_SIZE,
-    INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
     PRINT_PROGRESS_PER_N_NODES,
     SEARCH_LIMIT,
@@ -204,7 +203,9 @@ class QueryExecutor:
             if status.is_unlimited:
                 expression.limit = status.max_retrieve_batch_limit
             else:
-                expression.limit = max(min(INSTANCE_QUERY_LIMIT, status.max_retrieve_limit - status.total_retrieved), 0)
+                expression.limit = max(
+                    min(status.max_retrieve_batch_limit, status.max_retrieve_limit - status.total_retrieved), 0
+                )
 
     @property
     def _cursors(self) -> dict[str, str | None]:

--- a/cognite/pygen/_query/executor.py
+++ b/cognite/pygen/_query/executor.py
@@ -35,7 +35,7 @@ class Progress:
 
     def _update_nodes_per_second(self, last_node_count: int, last_execution_time: float) -> None:
         # Estimate the number of nodes per second using exponential moving average
-        last_batch_nodes_per_second = last_node_count / last_execution_time
+        last_batch_nodes_per_second = last_node_count / max(last_execution_time, 1e-6)
         if self._estimated_nodes_per_second == 0.0:
             self._estimated_nodes_per_second = last_batch_nodes_per_second
         else:

--- a/cognite/pygen/_query/step.py
+++ b/cognite/pygen/_query/step.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import Instance
 from cognite.client.data_classes.data_modeling.views import ReverseDirectRelation, ViewProperty
 
 from cognite.pygen._query.constants import (
+    ACTUAL_INSTANCE_QUERY_LIMIT,
     NODE_PROPERTIES,
     NotSetSentinel,
     SelectedProperties,
@@ -49,6 +50,7 @@ class QueryBuildStep:
         view_id: The view ID representing the view to query.
         max_retrieve_limit: The maximum number of instances to retrieve. Defaults to -1. If set to -1, it will
             continue to retrieve instances until there are no more instances to retrieve.
+        max_retrieve_batch_limit: The maximum number of instances to retrieve in a single batch. Defaults to -1.
         select: The selected properties to retrieve. If not set, it will default to all properties. None indicates
             to not retrieve any properties from the view.
         raw_filter: This is the same filter as the expression, but without the HasData filter. This is used to count
@@ -70,6 +72,7 @@ class QueryBuildStep:
         expression: dm.query.ResultSetExpression,
         view_id: dm.ViewId | None = None,
         max_retrieve_limit: int = -1,
+        max_retrieve_batch_limit: int | None = None,
         select: dm.query.Select | None | type[NotSetSentinel] = NotSetSentinel,
         raw_filter: dm.Filter | None = None,
         connection_type: Literal["reverse-list"] | None = None,
@@ -80,6 +83,7 @@ class QueryBuildStep:
         self.expression = expression
         self.view_id = view_id
         self.max_retrieve_limit = max_retrieve_limit
+        self._max_retrieve_batch_limit = max_retrieve_batch_limit
         self.select: dm.query.Select | None
         if select is NotSetSentinel:
             try:
@@ -127,6 +131,12 @@ class QueryBuildStep:
     @property
     def is_unlimited(self) -> bool:
         return self.max_retrieve_limit in {None, -1, math.inf}
+
+    @property
+    def max_retrieve_batch_limit(self) -> int:
+        if self._max_retrieve_batch_limit is None or self._max_retrieve_batch_limit in {-1, math.inf}:
+            return ACTUAL_INSTANCE_QUERY_LIMIT
+        return max(1, min(self._max_retrieve_batch_limit, ACTUAL_INSTANCE_QUERY_LIMIT))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, from={self.from_!r})"
@@ -223,6 +233,7 @@ class QueryBuildStepFactory:
         sort: list[dm.InstanceSort] | None = None,
         limit: int | None = None,
         has_container_fields: bool = True,
+        max_retrieve_batch_limit: int | None = None,
     ) -> QueryBuildStep:
         if self._root_properties:
             skip = NODE_PROPERTIES | set(self.reverse_properties.keys())
@@ -246,6 +257,7 @@ class QueryBuildStepFactory:
             view_id=self._view_id,
             max_retrieve_limit=-1 if limit is None else limit,
             raw_filter=filter,
+            max_retrieve_batch_limit=max_retrieve_batch_limit,
         )
 
     def from_connection(

--- a/examples/cognite_core/_api/_core.py
+++ b/examples/cognite_core/_api/_core.py
@@ -179,6 +179,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -205,15 +206,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/examples/cognite_core/_api/cognite_360_image.py
+++ b/examples/cognite_core/_api/cognite_360_image.py
@@ -991,6 +991,7 @@ class Cognite360ImageAPI(NodeAPI[Cognite360Image, Cognite360ImageWrite, Cognite3
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -999,6 +1000,7 @@ class Cognite360ImageAPI(NodeAPI[Cognite360Image, Cognite360ImageWrite, Cognite3
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_360_image_collection.py
+++ b/examples/cognite_core/_api/cognite_360_image_collection.py
@@ -510,6 +510,7 @@ class Cognite360ImageCollectionAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -518,6 +519,7 @@ class Cognite360ImageCollectionAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_360_image_model.py
+++ b/examples/cognite_core/_api/cognite_360_image_model.py
@@ -446,6 +446,7 @@ class Cognite360ImageModelAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -454,6 +455,7 @@ class Cognite360ImageModelAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_360_image_station.py
+++ b/examples/cognite_core/_api/cognite_360_image_station.py
@@ -395,6 +395,7 @@ class Cognite360ImageStationAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -403,6 +404,7 @@ class Cognite360ImageStationAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_3_d_model.py
+++ b/examples/cognite_core/_api/cognite_3_d_model.py
@@ -461,6 +461,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -469,6 +470,7 @@ class Cognite3DModelAPI(NodeAPI[Cognite3DModel, Cognite3DModelWrite, Cognite3DMo
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_3_d_object.py
+++ b/examples/cognite_core/_api/cognite_3_d_object.py
@@ -531,6 +531,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -539,6 +540,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_3_d_revision.py
+++ b/examples/cognite_core/_api/cognite_3_d_revision.py
@@ -452,6 +452,7 @@ class Cognite3DRevisionAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -460,6 +461,7 @@ class Cognite3DRevisionAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_3_d_transformation_node.py
+++ b/examples/cognite_core/_api/cognite_3_d_transformation_node.py
@@ -539,6 +539,7 @@ class Cognite3DTransformationNodeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -547,6 +548,7 @@ class Cognite3DTransformationNodeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_activity.py
+++ b/examples/cognite_core/_api/cognite_activity.py
@@ -837,6 +837,7 @@ class CogniteActivityAPI(NodeAPI[CogniteActivity, CogniteActivityWrite, CogniteA
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -845,6 +846,7 @@ class CogniteActivityAPI(NodeAPI[CogniteActivity, CogniteActivityWrite, CogniteA
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_asset.py
+++ b/examples/cognite_core/_api/cognite_asset.py
@@ -932,6 +932,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -940,6 +941,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_asset_class.py
+++ b/examples/cognite_core/_api/cognite_asset_class.py
@@ -419,6 +419,7 @@ class CogniteAssetClassAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -427,6 +428,7 @@ class CogniteAssetClassAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_asset_type.py
+++ b/examples/cognite_core/_api/cognite_asset_type.py
@@ -481,6 +481,7 @@ class CogniteAssetTypeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -489,6 +490,7 @@ class CogniteAssetTypeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_cad_model.py
+++ b/examples/cognite_core/_api/cognite_cad_model.py
@@ -444,6 +444,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -452,6 +453,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_cad_node.py
+++ b/examples/cognite_core/_api/cognite_cad_node.py
@@ -565,6 +565,7 @@ class CogniteCADNodeAPI(NodeAPI[CogniteCADNode, CogniteCADNodeWrite, CogniteCADN
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -573,6 +574,7 @@ class CogniteCADNodeAPI(NodeAPI[CogniteCADNode, CogniteCADNodeWrite, CogniteCADN
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_cad_revision.py
+++ b/examples/cognite_core/_api/cognite_cad_revision.py
@@ -455,6 +455,7 @@ class CogniteCADRevisionAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -463,6 +464,7 @@ class CogniteCADRevisionAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_cube_map.py
+++ b/examples/cognite_core/_api/cognite_cube_map.py
@@ -646,6 +646,7 @@ class CogniteCubeMapAPI(NodeAPI[CogniteCubeMap, CogniteCubeMapWrite, CogniteCube
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -653,6 +654,7 @@ class CogniteCubeMapAPI(NodeAPI[CogniteCubeMap, CogniteCubeMapWrite, CogniteCube
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_describable_node.py
+++ b/examples/cognite_core/_api/cognite_describable_node.py
@@ -506,6 +506,7 @@ class CogniteDescribableNodeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -514,6 +515,7 @@ class CogniteDescribableNodeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_equipment.py
+++ b/examples/cognite_core/_api/cognite_equipment.py
@@ -794,6 +794,7 @@ class CogniteEquipmentAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -802,6 +803,7 @@ class CogniteEquipmentAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_equipment_type.py
+++ b/examples/cognite_core/_api/cognite_equipment_type.py
@@ -467,6 +467,7 @@ class CogniteEquipmentTypeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -475,6 +476,7 @@ class CogniteEquipmentTypeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_file.py
+++ b/examples/cognite_core/_api/cognite_file.py
@@ -771,6 +771,7 @@ class CogniteFileAPI(NodeAPI[CogniteFile, CogniteFileWrite, CogniteFileList, Cog
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -779,6 +780,7 @@ class CogniteFileAPI(NodeAPI[CogniteFile, CogniteFileWrite, CogniteFileList, Cog
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_file_category.py
+++ b/examples/cognite_core/_api/cognite_file_category.py
@@ -443,6 +443,7 @@ class CogniteFileCategoryAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -451,6 +452,7 @@ class CogniteFileCategoryAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_point_cloud_model.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_model.py
@@ -458,6 +458,7 @@ class CognitePointCloudModelAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -466,6 +467,7 @@ class CognitePointCloudModelAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_point_cloud_revision.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_revision.py
@@ -462,6 +462,7 @@ class CognitePointCloudRevisionAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -470,6 +471,7 @@ class CognitePointCloudRevisionAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_point_cloud_volume.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_volume.py
@@ -594,6 +594,7 @@ class CognitePointCloudVolumeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -602,6 +603,7 @@ class CognitePointCloudVolumeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_schedulable.py
+++ b/examples/cognite_core/_api/cognite_schedulable.py
@@ -413,6 +413,7 @@ class CogniteSchedulableAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -421,6 +422,7 @@ class CogniteSchedulableAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_source_system.py
+++ b/examples/cognite_core/_api/cognite_source_system.py
@@ -419,6 +419,7 @@ class CogniteSourceSystemAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -427,6 +428,7 @@ class CogniteSourceSystemAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_sourceable_node.py
+++ b/examples/cognite_core/_api/cognite_sourceable_node.py
@@ -573,6 +573,7 @@ class CogniteSourceableNodeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -581,6 +582,7 @@ class CogniteSourceableNodeAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_time_series.py
+++ b/examples/cognite_core/_api/cognite_time_series.py
@@ -792,6 +792,7 @@ class CogniteTimeSeriesAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -800,6 +801,7 @@ class CogniteTimeSeriesAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_unit.py
+++ b/examples/cognite_core/_api/cognite_unit.py
@@ -465,6 +465,7 @@ class CogniteUnitAPI(NodeAPI[CogniteUnit, CogniteUnitWrite, CogniteUnitList, Cog
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -473,6 +474,7 @@ class CogniteUnitAPI(NodeAPI[CogniteUnit, CogniteUnitWrite, CogniteUnitList, Cog
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/_api/cognite_visualizable.py
+++ b/examples/cognite_core/_api/cognite_visualizable.py
@@ -378,6 +378,7 @@ class CogniteVisualizableAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -385,6 +386,7 @@ class CogniteVisualizableAPI(
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/cognite_core/data_classes/_core/query/executor.py
+++ b/examples/cognite_core/data_classes/_core/query/executor.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes.aggregations import Count
 from cognite.client.exceptions import CogniteAPIError
 
 from cognite_core.data_classes._core.query.constants import (
-    ACTUAL_INSTANCE_QUERY_LIMIT,
     IN_FILTER_CHUNK_SIZE,
     INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
@@ -36,7 +35,7 @@ class Progress:
 
     def _update_nodes_per_second(self, last_node_count: int, last_execution_time: float) -> None:
         # Estimate the number of nodes per second using exponential moving average
-        last_batch_nodes_per_second = last_node_count / last_execution_time
+        last_batch_nodes_per_second = last_node_count / max(last_execution_time, 1e-6)
         if self._estimated_nodes_per_second == 0.0:
             self._estimated_nodes_per_second = last_batch_nodes_per_second
         else:
@@ -68,7 +67,7 @@ class PaginationStatus:
     is_unlimited: bool
     max_retrieve_limit: int
     is_queryable: bool
-    max_retrieve_batch_limit = ACTUAL_INSTANCE_QUERY_LIMIT
+    max_retrieve_batch_limit: int = INSTANCE_QUERY_LIMIT
     cursor: str | None = None
     total_retrieved: int = 0
     last_batch_count: int = 0
@@ -119,7 +118,13 @@ class QueryExecutor:
         self._to_search = to_search
         self._temp_select = temp_select
         self._status_by_name = {
-            step.name: PaginationStatus(step.is_unlimited, step.max_retrieve_limit, step.is_queryable) for step in steps
+            step.name: PaginationStatus(
+                step.is_unlimited,
+                step.max_retrieve_limit,
+                step.is_queryable,
+                max_retrieve_batch_limit=step.max_retrieve_batch_limit,
+            )
+            for step in steps
         }
 
     def execute_query(
@@ -159,13 +164,13 @@ class QueryExecutor:
                 if e.code == 408:
                     # Too big query, try to reduce the limit
                     if self._reduce_max_batch_limit():
+                        new_limit = status.max_retrieve_batch_limit
+                        warnings.warn(
+                            f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
+                            QueryReducingBatchSize,
+                            stacklevel=2,
+                        )
                         continue
-                    new_limit = status.max_retrieve_batch_limit
-                    warnings.warn(
-                        f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
-                        QueryReducingBatchSize,
-                        stacklevel=2,
-                    )
 
                 raise e
 
@@ -199,7 +204,9 @@ class QueryExecutor:
             if status.is_unlimited:
                 expression.limit = status.max_retrieve_batch_limit
             else:
-                expression.limit = max(min(INSTANCE_QUERY_LIMIT, status.max_retrieve_limit - status.total_retrieved), 0)
+                expression.limit = max(
+                    min(status.max_retrieve_batch_limit, status.max_retrieve_limit - status.total_retrieved), 0
+                )
 
     @property
     def _cursors(self) -> dict[str, str | None]:

--- a/examples/cognite_core/data_classes/_core/query/step.py
+++ b/examples/cognite_core/data_classes/_core/query/step.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import Instance
 from cognite.client.data_classes.data_modeling.views import ReverseDirectRelation, ViewProperty
 
 from cognite_core.data_classes._core.query.constants import (
+    ACTUAL_INSTANCE_QUERY_LIMIT,
     NODE_PROPERTIES,
     NotSetSentinel,
     SelectedProperties,
@@ -49,6 +50,7 @@ class QueryBuildStep:
         view_id: The view ID representing the view to query.
         max_retrieve_limit: The maximum number of instances to retrieve. Defaults to -1. If set to -1, it will
             continue to retrieve instances until there are no more instances to retrieve.
+        max_retrieve_batch_limit: The maximum number of instances to retrieve in a single batch. Defaults to -1.
         select: The selected properties to retrieve. If not set, it will default to all properties. None indicates
             to not retrieve any properties from the view.
         raw_filter: This is the same filter as the expression, but without the HasData filter. This is used to count
@@ -70,6 +72,7 @@ class QueryBuildStep:
         expression: dm.query.ResultSetExpression,
         view_id: dm.ViewId | None = None,
         max_retrieve_limit: int = -1,
+        max_retrieve_batch_limit: int | None = None,
         select: dm.query.Select | None | type[NotSetSentinel] = NotSetSentinel,
         raw_filter: dm.Filter | None = None,
         connection_type: Literal["reverse-list"] | None = None,
@@ -80,6 +83,7 @@ class QueryBuildStep:
         self.expression = expression
         self.view_id = view_id
         self.max_retrieve_limit = max_retrieve_limit
+        self._max_retrieve_batch_limit = max_retrieve_batch_limit
         self.select: dm.query.Select | None
         if select is NotSetSentinel:
             try:
@@ -127,6 +131,12 @@ class QueryBuildStep:
     @property
     def is_unlimited(self) -> bool:
         return self.max_retrieve_limit in {None, -1, math.inf}
+
+    @property
+    def max_retrieve_batch_limit(self) -> int:
+        if self._max_retrieve_batch_limit is None or self._max_retrieve_batch_limit in {-1, math.inf}:
+            return ACTUAL_INSTANCE_QUERY_LIMIT
+        return max(1, min(self._max_retrieve_batch_limit, ACTUAL_INSTANCE_QUERY_LIMIT))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, from={self.from_!r})"
@@ -223,6 +233,7 @@ class QueryBuildStepFactory:
         sort: list[dm.InstanceSort] | None = None,
         limit: int | None = None,
         has_container_fields: bool = True,
+        max_retrieve_batch_limit: int | None = None,
     ) -> QueryBuildStep:
         if self._root_properties:
             skip = NODE_PROPERTIES | set(self.reverse_properties.keys())
@@ -246,6 +257,7 @@ class QueryBuildStepFactory:
             view_id=self._view_id,
             max_retrieve_limit=-1 if limit is None else limit,
             raw_filter=filter,
+            max_retrieve_batch_limit=max_retrieve_batch_limit,
         )
 
     def from_connection(

--- a/examples/omni/_api/_core.py
+++ b/examples/omni/_api/_core.py
@@ -179,6 +179,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -205,15 +206,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/examples/omni/_api/cdf_external_references.py
+++ b/examples/omni/_api/cdf_external_references.py
@@ -311,6 +311,7 @@ class CDFExternalReferencesAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -319,6 +320,7 @@ class CDFExternalReferencesAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/cdf_external_references_listed.py
+++ b/examples/omni/_api/cdf_external_references_listed.py
@@ -316,6 +316,7 @@ class CDFExternalReferencesListedAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -324,6 +325,7 @@ class CDFExternalReferencesListedAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_a.py
+++ b/examples/omni/_api/connection_item_a.py
@@ -465,6 +465,7 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -473,6 +474,7 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_b.py
+++ b/examples/omni/_api/connection_item_b.py
@@ -358,6 +358,7 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -366,6 +367,7 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_c_node.py
+++ b/examples/omni/_api/connection_item_c_node.py
@@ -322,6 +322,7 @@ class ConnectionItemCNodeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -329,6 +330,7 @@ class ConnectionItemCNodeAPI(
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=False,
             )
         )

--- a/examples/omni/_api/connection_item_d.py
+++ b/examples/omni/_api/connection_item_d.py
@@ -464,6 +464,7 @@ class ConnectionItemDAPI(NodeAPI[ConnectionItemD, ConnectionItemDWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -472,6 +473,7 @@ class ConnectionItemDAPI(NodeAPI[ConnectionItemD, ConnectionItemDWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_e.py
+++ b/examples/omni/_api/connection_item_e.py
@@ -472,6 +472,7 @@ class ConnectionItemEAPI(NodeAPI[ConnectionItemE, ConnectionItemEWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -480,6 +481,7 @@ class ConnectionItemEAPI(NodeAPI[ConnectionItemE, ConnectionItemEWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_f.py
+++ b/examples/omni/_api/connection_item_f.py
@@ -418,6 +418,7 @@ class ConnectionItemFAPI(NodeAPI[ConnectionItemF, ConnectionItemFWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -426,6 +427,7 @@ class ConnectionItemFAPI(NodeAPI[ConnectionItemF, ConnectionItemFWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/connection_item_g.py
+++ b/examples/omni/_api/connection_item_g.py
@@ -360,6 +360,7 @@ class ConnectionItemGAPI(NodeAPI[ConnectionItemG, ConnectionItemGWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -368,6 +369,7 @@ class ConnectionItemGAPI(NodeAPI[ConnectionItemG, ConnectionItemGWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/dependent_on_non_writable.py
+++ b/examples/omni/_api/dependent_on_non_writable.py
@@ -370,6 +370,7 @@ class DependentOnNonWritableAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -378,6 +379,7 @@ class DependentOnNonWritableAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/empty.py
+++ b/examples/omni/_api/empty.py
@@ -502,6 +502,7 @@ class EmptyAPI(NodeAPI[Empty, EmptyWrite, EmptyList, EmptyWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -510,6 +511,7 @@ class EmptyAPI(NodeAPI[Empty, EmptyWrite, EmptyList, EmptyWriteList]):
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/implementation_1.py
+++ b/examples/omni/_api/implementation_1.py
@@ -417,6 +417,7 @@ class Implementation1API(NodeAPI[Implementation1, Implementation1Write, Implemen
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -425,6 +426,7 @@ class Implementation1API(NodeAPI[Implementation1, Implementation1Write, Implemen
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/implementation_1_non_writeable.py
+++ b/examples/omni/_api/implementation_1_non_writeable.py
@@ -464,6 +464,7 @@ class Implementation1NonWriteableAPI(NodeReadAPI[Implementation1NonWriteable, Im
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -472,6 +473,7 @@ class Implementation1NonWriteableAPI(NodeReadAPI[Implementation1NonWriteable, Im
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/implementation_2.py
+++ b/examples/omni/_api/implementation_2.py
@@ -369,6 +369,7 @@ class Implementation2API(NodeAPI[Implementation2, Implementation2Write, Implemen
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -377,6 +378,7 @@ class Implementation2API(NodeAPI[Implementation2, Implementation2Write, Implemen
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/main_interface.py
+++ b/examples/omni/_api/main_interface.py
@@ -354,6 +354,7 @@ class MainInterfaceAPI(NodeAPI[MainInterface, MainInterfaceWrite, MainInterfaceL
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -362,6 +363,7 @@ class MainInterfaceAPI(NodeAPI[MainInterface, MainInterfaceWrite, MainInterfaceL
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/primitive_nullable.py
+++ b/examples/omni/_api/primitive_nullable.py
@@ -504,6 +504,7 @@ class PrimitiveNullableAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -512,6 +513,7 @@ class PrimitiveNullableAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/primitive_nullable_listed.py
+++ b/examples/omni/_api/primitive_nullable_listed.py
@@ -339,6 +339,7 @@ class PrimitiveNullableListedAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -347,6 +348,7 @@ class PrimitiveNullableListedAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/primitive_required.py
+++ b/examples/omni/_api/primitive_required.py
@@ -504,6 +504,7 @@ class PrimitiveRequiredAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -512,6 +513,7 @@ class PrimitiveRequiredAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/primitive_required_listed.py
+++ b/examples/omni/_api/primitive_required_listed.py
@@ -339,6 +339,7 @@ class PrimitiveRequiredListedAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -347,6 +348,7 @@ class PrimitiveRequiredListedAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/primitive_with_defaults.py
+++ b/examples/omni/_api/primitive_with_defaults.py
@@ -419,6 +419,7 @@ class PrimitiveWithDefaultsAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -427,6 +428,7 @@ class PrimitiveWithDefaultsAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni/_api/sub_interface.py
+++ b/examples/omni/_api/sub_interface.py
@@ -386,6 +386,7 @@ class SubInterfaceAPI(NodeAPI[SubInterface, SubInterfaceWrite, SubInterfaceList,
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -394,6 +395,7 @@ class SubInterfaceAPI(NodeAPI[SubInterface, SubInterfaceWrite, SubInterfaceList,
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_multi/_api/_core.py
+++ b/examples/omni_multi/_api/_core.py
@@ -178,6 +178,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -204,15 +205,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/examples/omni_multi/_api/implementation_1_v_1.py
+++ b/examples/omni_multi/_api/implementation_1_v_1.py
@@ -394,6 +394,7 @@ class Implementation1v1API(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -402,6 +403,7 @@ class Implementation1v1API(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_multi/_api/implementation_1_v_2.py
+++ b/examples/omni_multi/_api/implementation_1_v_2.py
@@ -394,6 +394,7 @@ class Implementation1v2API(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -402,6 +403,7 @@ class Implementation1v2API(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_multi/_api/main_interface.py
+++ b/examples/omni_multi/_api/main_interface.py
@@ -351,6 +351,7 @@ class MainInterfaceAPI(NodeAPI[MainInterface, MainInterfaceWrite, MainInterfaceL
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -359,6 +360,7 @@ class MainInterfaceAPI(NodeAPI[MainInterface, MainInterfaceWrite, MainInterfaceL
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_multi/_api/sub_interface.py
+++ b/examples/omni_multi/_api/sub_interface.py
@@ -375,6 +375,7 @@ class SubInterfaceAPI(NodeAPI[SubInterface, SubInterfaceWrite, SubInterfaceList,
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -383,6 +384,7 @@ class SubInterfaceAPI(NodeAPI[SubInterface, SubInterfaceWrite, SubInterfaceList,
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_multi/data_classes/_core/query/executor.py
+++ b/examples/omni_multi/data_classes/_core/query/executor.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes.aggregations import Count
 from cognite.client.exceptions import CogniteAPIError
 
 from omni_multi.data_classes._core.query.constants import (
-    ACTUAL_INSTANCE_QUERY_LIMIT,
     IN_FILTER_CHUNK_SIZE,
     INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
@@ -36,7 +35,7 @@ class Progress:
 
     def _update_nodes_per_second(self, last_node_count: int, last_execution_time: float) -> None:
         # Estimate the number of nodes per second using exponential moving average
-        last_batch_nodes_per_second = last_node_count / last_execution_time
+        last_batch_nodes_per_second = last_node_count / max(last_execution_time, 1e-6)
         if self._estimated_nodes_per_second == 0.0:
             self._estimated_nodes_per_second = last_batch_nodes_per_second
         else:
@@ -68,7 +67,7 @@ class PaginationStatus:
     is_unlimited: bool
     max_retrieve_limit: int
     is_queryable: bool
-    max_retrieve_batch_limit = ACTUAL_INSTANCE_QUERY_LIMIT
+    max_retrieve_batch_limit: int = INSTANCE_QUERY_LIMIT
     cursor: str | None = None
     total_retrieved: int = 0
     last_batch_count: int = 0
@@ -119,7 +118,13 @@ class QueryExecutor:
         self._to_search = to_search
         self._temp_select = temp_select
         self._status_by_name = {
-            step.name: PaginationStatus(step.is_unlimited, step.max_retrieve_limit, step.is_queryable) for step in steps
+            step.name: PaginationStatus(
+                step.is_unlimited,
+                step.max_retrieve_limit,
+                step.is_queryable,
+                max_retrieve_batch_limit=step.max_retrieve_batch_limit,
+            )
+            for step in steps
         }
 
     def execute_query(
@@ -159,13 +164,13 @@ class QueryExecutor:
                 if e.code == 408:
                     # Too big query, try to reduce the limit
                     if self._reduce_max_batch_limit():
+                        new_limit = status.max_retrieve_batch_limit
+                        warnings.warn(
+                            f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
+                            QueryReducingBatchSize,
+                            stacklevel=2,
+                        )
                         continue
-                    new_limit = status.max_retrieve_batch_limit
-                    warnings.warn(
-                        f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
-                        QueryReducingBatchSize,
-                        stacklevel=2,
-                    )
 
                 raise e
 
@@ -199,7 +204,9 @@ class QueryExecutor:
             if status.is_unlimited:
                 expression.limit = status.max_retrieve_batch_limit
             else:
-                expression.limit = max(min(INSTANCE_QUERY_LIMIT, status.max_retrieve_limit - status.total_retrieved), 0)
+                expression.limit = max(
+                    min(status.max_retrieve_batch_limit, status.max_retrieve_limit - status.total_retrieved), 0
+                )
 
     @property
     def _cursors(self) -> dict[str, str | None]:

--- a/examples/omni_multi/data_classes/_core/query/step.py
+++ b/examples/omni_multi/data_classes/_core/query/step.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import Instance
 from cognite.client.data_classes.data_modeling.views import ReverseDirectRelation, ViewProperty
 
 from omni_multi.data_classes._core.query.constants import (
+    ACTUAL_INSTANCE_QUERY_LIMIT,
     NODE_PROPERTIES,
     NotSetSentinel,
     SelectedProperties,
@@ -49,6 +50,7 @@ class QueryBuildStep:
         view_id: The view ID representing the view to query.
         max_retrieve_limit: The maximum number of instances to retrieve. Defaults to -1. If set to -1, it will
             continue to retrieve instances until there are no more instances to retrieve.
+        max_retrieve_batch_limit: The maximum number of instances to retrieve in a single batch. Defaults to -1.
         select: The selected properties to retrieve. If not set, it will default to all properties. None indicates
             to not retrieve any properties from the view.
         raw_filter: This is the same filter as the expression, but without the HasData filter. This is used to count
@@ -70,6 +72,7 @@ class QueryBuildStep:
         expression: dm.query.ResultSetExpression,
         view_id: dm.ViewId | None = None,
         max_retrieve_limit: int = -1,
+        max_retrieve_batch_limit: int | None = None,
         select: dm.query.Select | None | type[NotSetSentinel] = NotSetSentinel,
         raw_filter: dm.Filter | None = None,
         connection_type: Literal["reverse-list"] | None = None,
@@ -80,6 +83,7 @@ class QueryBuildStep:
         self.expression = expression
         self.view_id = view_id
         self.max_retrieve_limit = max_retrieve_limit
+        self._max_retrieve_batch_limit = max_retrieve_batch_limit
         self.select: dm.query.Select | None
         if select is NotSetSentinel:
             try:
@@ -127,6 +131,12 @@ class QueryBuildStep:
     @property
     def is_unlimited(self) -> bool:
         return self.max_retrieve_limit in {None, -1, math.inf}
+
+    @property
+    def max_retrieve_batch_limit(self) -> int:
+        if self._max_retrieve_batch_limit is None or self._max_retrieve_batch_limit in {-1, math.inf}:
+            return ACTUAL_INSTANCE_QUERY_LIMIT
+        return max(1, min(self._max_retrieve_batch_limit, ACTUAL_INSTANCE_QUERY_LIMIT))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, from={self.from_!r})"
@@ -223,6 +233,7 @@ class QueryBuildStepFactory:
         sort: list[dm.InstanceSort] | None = None,
         limit: int | None = None,
         has_container_fields: bool = True,
+        max_retrieve_batch_limit: int | None = None,
     ) -> QueryBuildStep:
         if self._root_properties:
             skip = NODE_PROPERTIES | set(self.reverse_properties.keys())
@@ -246,6 +257,7 @@ class QueryBuildStepFactory:
             view_id=self._view_id,
             max_retrieve_limit=-1 if limit is None else limit,
             raw_filter=filter,
+            max_retrieve_batch_limit=max_retrieve_batch_limit,
         )
 
     def from_connection(

--- a/examples/omni_sub/_api/_core.py
+++ b/examples/omni_sub/_api/_core.py
@@ -178,6 +178,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -204,15 +205,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/examples/omni_sub/_api/connection_item_a.py
+++ b/examples/omni_sub/_api/connection_item_a.py
@@ -452,6 +452,7 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -460,6 +461,7 @@ class ConnectionItemAAPI(NodeAPI[ConnectionItemA, ConnectionItemAWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_sub/_api/connection_item_b.py
+++ b/examples/omni_sub/_api/connection_item_b.py
@@ -357,6 +357,7 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -365,6 +366,7 @@ class ConnectionItemBAPI(NodeAPI[ConnectionItemB, ConnectionItemBWrite, Connecti
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/omni_sub/_api/connection_item_c_node.py
+++ b/examples/omni_sub/_api/connection_item_c_node.py
@@ -321,6 +321,7 @@ class ConnectionItemCNodeAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -328,6 +329,7 @@ class ConnectionItemCNodeAPI(
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=False,
             )
         )

--- a/examples/omni_sub/data_classes/_core/query/executor.py
+++ b/examples/omni_sub/data_classes/_core/query/executor.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes.aggregations import Count
 from cognite.client.exceptions import CogniteAPIError
 
 from omni_sub.data_classes._core.query.constants import (
-    ACTUAL_INSTANCE_QUERY_LIMIT,
     IN_FILTER_CHUNK_SIZE,
     INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
@@ -36,7 +35,7 @@ class Progress:
 
     def _update_nodes_per_second(self, last_node_count: int, last_execution_time: float) -> None:
         # Estimate the number of nodes per second using exponential moving average
-        last_batch_nodes_per_second = last_node_count / last_execution_time
+        last_batch_nodes_per_second = last_node_count / max(last_execution_time, 1e-6)
         if self._estimated_nodes_per_second == 0.0:
             self._estimated_nodes_per_second = last_batch_nodes_per_second
         else:
@@ -68,7 +67,7 @@ class PaginationStatus:
     is_unlimited: bool
     max_retrieve_limit: int
     is_queryable: bool
-    max_retrieve_batch_limit = ACTUAL_INSTANCE_QUERY_LIMIT
+    max_retrieve_batch_limit: int = INSTANCE_QUERY_LIMIT
     cursor: str | None = None
     total_retrieved: int = 0
     last_batch_count: int = 0
@@ -119,7 +118,13 @@ class QueryExecutor:
         self._to_search = to_search
         self._temp_select = temp_select
         self._status_by_name = {
-            step.name: PaginationStatus(step.is_unlimited, step.max_retrieve_limit, step.is_queryable) for step in steps
+            step.name: PaginationStatus(
+                step.is_unlimited,
+                step.max_retrieve_limit,
+                step.is_queryable,
+                max_retrieve_batch_limit=step.max_retrieve_batch_limit,
+            )
+            for step in steps
         }
 
     def execute_query(
@@ -159,13 +164,13 @@ class QueryExecutor:
                 if e.code == 408:
                     # Too big query, try to reduce the limit
                     if self._reduce_max_batch_limit():
+                        new_limit = status.max_retrieve_batch_limit
+                        warnings.warn(
+                            f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
+                            QueryReducingBatchSize,
+                            stacklevel=2,
+                        )
                         continue
-                    new_limit = status.max_retrieve_batch_limit
-                    warnings.warn(
-                        f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
-                        QueryReducingBatchSize,
-                        stacklevel=2,
-                    )
 
                 raise e
 
@@ -199,7 +204,9 @@ class QueryExecutor:
             if status.is_unlimited:
                 expression.limit = status.max_retrieve_batch_limit
             else:
-                expression.limit = max(min(INSTANCE_QUERY_LIMIT, status.max_retrieve_limit - status.total_retrieved), 0)
+                expression.limit = max(
+                    min(status.max_retrieve_batch_limit, status.max_retrieve_limit - status.total_retrieved), 0
+                )
 
     @property
     def _cursors(self) -> dict[str, str | None]:

--- a/examples/omni_sub/data_classes/_core/query/step.py
+++ b/examples/omni_sub/data_classes/_core/query/step.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import Instance
 from cognite.client.data_classes.data_modeling.views import ReverseDirectRelation, ViewProperty
 
 from omni_sub.data_classes._core.query.constants import (
+    ACTUAL_INSTANCE_QUERY_LIMIT,
     NODE_PROPERTIES,
     NotSetSentinel,
     SelectedProperties,
@@ -49,6 +50,7 @@ class QueryBuildStep:
         view_id: The view ID representing the view to query.
         max_retrieve_limit: The maximum number of instances to retrieve. Defaults to -1. If set to -1, it will
             continue to retrieve instances until there are no more instances to retrieve.
+        max_retrieve_batch_limit: The maximum number of instances to retrieve in a single batch. Defaults to -1.
         select: The selected properties to retrieve. If not set, it will default to all properties. None indicates
             to not retrieve any properties from the view.
         raw_filter: This is the same filter as the expression, but without the HasData filter. This is used to count
@@ -70,6 +72,7 @@ class QueryBuildStep:
         expression: dm.query.ResultSetExpression,
         view_id: dm.ViewId | None = None,
         max_retrieve_limit: int = -1,
+        max_retrieve_batch_limit: int | None = None,
         select: dm.query.Select | None | type[NotSetSentinel] = NotSetSentinel,
         raw_filter: dm.Filter | None = None,
         connection_type: Literal["reverse-list"] | None = None,
@@ -80,6 +83,7 @@ class QueryBuildStep:
         self.expression = expression
         self.view_id = view_id
         self.max_retrieve_limit = max_retrieve_limit
+        self._max_retrieve_batch_limit = max_retrieve_batch_limit
         self.select: dm.query.Select | None
         if select is NotSetSentinel:
             try:
@@ -127,6 +131,12 @@ class QueryBuildStep:
     @property
     def is_unlimited(self) -> bool:
         return self.max_retrieve_limit in {None, -1, math.inf}
+
+    @property
+    def max_retrieve_batch_limit(self) -> int:
+        if self._max_retrieve_batch_limit is None or self._max_retrieve_batch_limit in {-1, math.inf}:
+            return ACTUAL_INSTANCE_QUERY_LIMIT
+        return max(1, min(self._max_retrieve_batch_limit, ACTUAL_INSTANCE_QUERY_LIMIT))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, from={self.from_!r})"
@@ -223,6 +233,7 @@ class QueryBuildStepFactory:
         sort: list[dm.InstanceSort] | None = None,
         limit: int | None = None,
         has_container_fields: bool = True,
+        max_retrieve_batch_limit: int | None = None,
     ) -> QueryBuildStep:
         if self._root_properties:
             skip = NODE_PROPERTIES | set(self.reverse_properties.keys())
@@ -246,6 +257,7 @@ class QueryBuildStepFactory:
             view_id=self._view_id,
             max_retrieve_limit=-1 if limit is None else limit,
             raw_filter=filter,
+            max_retrieve_batch_limit=max_retrieve_batch_limit,
         )
 
     def from_connection(

--- a/examples/wind_turbine/_api/_core.py
+++ b/examples/wind_turbine/_api/_core.py
@@ -179,6 +179,7 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         raise NotImplementedError
 
@@ -205,15 +206,13 @@ class NodeReadAPI(Generic[T_DomainModel, T_DomainModelList], ABC):
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
     ) -> Iterator[T_DomainModelList]:
-        executor = self._build(filter_, limit, retrieve_connections, sort)
+        executor = self._build(filter_, limit, retrieve_connections, sort, chunk_size)
         for batch_results in executor.iterate(self._client, remove_not_connected=False):
             unpack_edges: Literal["skip", "identifier"] = (
                 "identifier" if retrieve_connections == "identifier" else "skip"
             )
             unpacked = QueryUnpacker(batch_results, edges=unpack_edges).unpack()
-            item_list = self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
-            for i in range(0, len(item_list), chunk_size):
-                yield item_list[i : i + chunk_size]
+            yield self._class_list(instantiate_classes(self._class_type, unpacked, "iterate"))
 
     def _search(
         self,

--- a/examples/wind_turbine/_api/blade.py
+++ b/examples/wind_turbine/_api/blade.py
@@ -365,6 +365,7 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList, BladeWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -373,6 +374,7 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList, BladeWriteList]):
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/data_sheet.py
+++ b/examples/wind_turbine/_api/data_sheet.py
@@ -454,6 +454,7 @@ class DataSheetAPI(NodeAPI[DataSheet, DataSheetWrite, DataSheetList, DataSheetWr
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -462,6 +463,7 @@ class DataSheetAPI(NodeAPI[DataSheet, DataSheetWrite, DataSheetList, DataSheetWr
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/gearbox.py
+++ b/examples/wind_turbine/_api/gearbox.py
@@ -477,6 +477,7 @@ class GearboxAPI(NodeAPI[Gearbox, GearboxWrite, GearboxList, GearboxWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -484,6 +485,7 @@ class GearboxAPI(NodeAPI[Gearbox, GearboxWrite, GearboxList, GearboxWriteList]):
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/generating_unit.py
+++ b/examples/wind_turbine/_api/generating_unit.py
@@ -402,6 +402,7 @@ class GeneratingUnitAPI(NodeAPI[GeneratingUnit, GeneratingUnitWrite, GeneratingU
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -410,6 +411,7 @@ class GeneratingUnitAPI(NodeAPI[GeneratingUnit, GeneratingUnitWrite, GeneratingU
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/generator.py
+++ b/examples/wind_turbine/_api/generator.py
@@ -424,6 +424,7 @@ class GeneratorAPI(NodeAPI[Generator, GeneratorWrite, GeneratorList, GeneratorWr
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -431,6 +432,7 @@ class GeneratorAPI(NodeAPI[Generator, GeneratorWrite, GeneratorList, GeneratorWr
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/high_speed_shaft.py
+++ b/examples/wind_turbine/_api/high_speed_shaft.py
@@ -477,6 +477,7 @@ class HighSpeedShaftAPI(NodeAPI[HighSpeedShaft, HighSpeedShaftWrite, HighSpeedSh
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -484,6 +485,7 @@ class HighSpeedShaftAPI(NodeAPI[HighSpeedShaft, HighSpeedShaftWrite, HighSpeedSh
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/main_shaft.py
+++ b/examples/wind_turbine/_api/main_shaft.py
@@ -586,6 +586,7 @@ class MainShaftAPI(NodeAPI[MainShaft, MainShaftWrite, MainShaftList, MainShaftWr
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -593,6 +594,7 @@ class MainShaftAPI(NodeAPI[MainShaft, MainShaftWrite, MainShaftList, MainShaftWr
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/metmast.py
+++ b/examples/wind_turbine/_api/metmast.py
@@ -346,6 +346,7 @@ class MetmastAPI(NodeAPI[Metmast, MetmastWrite, MetmastList, MetmastWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -354,6 +355,7 @@ class MetmastAPI(NodeAPI[Metmast, MetmastWrite, MetmastList, MetmastWriteList]):
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/nacelle.py
+++ b/examples/wind_turbine/_api/nacelle.py
@@ -861,6 +861,7 @@ class NacelleAPI(NodeAPI[Nacelle, NacelleWrite, NacelleList, NacelleWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -868,6 +869,7 @@ class NacelleAPI(NodeAPI[Nacelle, NacelleWrite, NacelleList, NacelleWriteList]):
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/power_inverter.py
+++ b/examples/wind_turbine/_api/power_inverter.py
@@ -478,6 +478,7 @@ class PowerInverterAPI(NodeAPI[PowerInverter, PowerInverterWrite, PowerInverterL
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -485,6 +486,7 @@ class PowerInverterAPI(NodeAPI[PowerInverter, PowerInverterWrite, PowerInverterL
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/rotor.py
+++ b/examples/wind_turbine/_api/rotor.py
@@ -423,6 +423,7 @@ class RotorAPI(NodeAPI[Rotor, RotorWrite, RotorList, RotorWriteList]):
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -430,6 +431,7 @@ class RotorAPI(NodeAPI[Rotor, RotorWrite, RotorList, RotorWriteList]):
             factory.root(
                 filter=filter_,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/sensor_position.py
+++ b/examples/wind_turbine/_api/sensor_position.py
@@ -829,6 +829,7 @@ class SensorPositionAPI(NodeAPI[SensorPosition, SensorPositionWrite, SensorPosit
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -837,6 +838,7 @@ class SensorPositionAPI(NodeAPI[SensorPosition, SensorPositionWrite, SensorPosit
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/sensor_time_series.py
+++ b/examples/wind_turbine/_api/sensor_time_series.py
@@ -467,6 +467,7 @@ class SensorTimeSeriesAPI(
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -475,6 +476,7 @@ class SensorTimeSeriesAPI(
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/solar_panel.py
+++ b/examples/wind_turbine/_api/solar_panel.py
@@ -509,6 +509,7 @@ class SolarPanelAPI(NodeAPI[SolarPanel, SolarPanelWrite, SolarPanelList, SolarPa
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -517,6 +518,7 @@ class SolarPanelAPI(NodeAPI[SolarPanel, SolarPanelWrite, SolarPanelList, SolarPa
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/_api/wind_turbine.py
+++ b/examples/wind_turbine/_api/wind_turbine.py
@@ -652,6 +652,7 @@ class WindTurbineAPI(NodeAPI[WindTurbine, WindTurbineWrite, WindTurbineList, Win
         limit: int | None,
         retrieve_connections: Literal["skip", "identifier", "full"],
         sort: list[InstanceSort] | None = None,
+        chunk_size: int | None = None,
     ) -> QueryExecutor:
         builder = QueryBuilder()
         factory = QueryBuildStepFactory(builder.create_name, view_id=self._view_id, edge_connection_property="end_node")
@@ -660,6 +661,7 @@ class WindTurbineAPI(NodeAPI[WindTurbine, WindTurbineWrite, WindTurbineList, Win
                 filter=filter_,
                 sort=sort,
                 limit=limit,
+                max_retrieve_batch_limit=chunk_size,
                 has_container_fields=True,
             )
         )

--- a/examples/wind_turbine/data_classes/_core/query/executor.py
+++ b/examples/wind_turbine/data_classes/_core/query/executor.py
@@ -10,7 +10,6 @@ from cognite.client.data_classes.aggregations import Count
 from cognite.client.exceptions import CogniteAPIError
 
 from wind_turbine.data_classes._core.query.constants import (
-    ACTUAL_INSTANCE_QUERY_LIMIT,
     IN_FILTER_CHUNK_SIZE,
     INSTANCE_QUERY_LIMIT,
     MINIMUM_ESTIMATED_SECONDS_BEFORE_PRINT_PROGRESS,
@@ -36,7 +35,7 @@ class Progress:
 
     def _update_nodes_per_second(self, last_node_count: int, last_execution_time: float) -> None:
         # Estimate the number of nodes per second using exponential moving average
-        last_batch_nodes_per_second = last_node_count / last_execution_time
+        last_batch_nodes_per_second = last_node_count / max(last_execution_time, 1e-6)
         if self._estimated_nodes_per_second == 0.0:
             self._estimated_nodes_per_second = last_batch_nodes_per_second
         else:
@@ -68,7 +67,7 @@ class PaginationStatus:
     is_unlimited: bool
     max_retrieve_limit: int
     is_queryable: bool
-    max_retrieve_batch_limit = ACTUAL_INSTANCE_QUERY_LIMIT
+    max_retrieve_batch_limit: int = INSTANCE_QUERY_LIMIT
     cursor: str | None = None
     total_retrieved: int = 0
     last_batch_count: int = 0
@@ -119,7 +118,13 @@ class QueryExecutor:
         self._to_search = to_search
         self._temp_select = temp_select
         self._status_by_name = {
-            step.name: PaginationStatus(step.is_unlimited, step.max_retrieve_limit, step.is_queryable) for step in steps
+            step.name: PaginationStatus(
+                step.is_unlimited,
+                step.max_retrieve_limit,
+                step.is_queryable,
+                max_retrieve_batch_limit=step.max_retrieve_batch_limit,
+            )
+            for step in steps
         }
 
     def execute_query(
@@ -159,13 +164,13 @@ class QueryExecutor:
                 if e.code == 408:
                     # Too big query, try to reduce the limit
                     if self._reduce_max_batch_limit():
+                        new_limit = status.max_retrieve_batch_limit
+                        warnings.warn(
+                            f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
+                            QueryReducingBatchSize,
+                            stacklevel=2,
+                        )
                         continue
-                    new_limit = status.max_retrieve_batch_limit
-                    warnings.warn(
-                        f"Query is too large, reducing batch size to {new_limit:,}, and trying again",
-                        QueryReducingBatchSize,
-                        stacklevel=2,
-                    )
 
                 raise e
 
@@ -199,7 +204,9 @@ class QueryExecutor:
             if status.is_unlimited:
                 expression.limit = status.max_retrieve_batch_limit
             else:
-                expression.limit = max(min(INSTANCE_QUERY_LIMIT, status.max_retrieve_limit - status.total_retrieved), 0)
+                expression.limit = max(
+                    min(status.max_retrieve_batch_limit, status.max_retrieve_limit - status.total_retrieved), 0
+                )
 
     @property
     def _cursors(self) -> dict[str, str | None]:

--- a/examples/wind_turbine/data_classes/_core/query/step.py
+++ b/examples/wind_turbine/data_classes/_core/query/step.py
@@ -12,6 +12,7 @@ from cognite.client.data_classes.data_modeling.instances import Instance
 from cognite.client.data_classes.data_modeling.views import ReverseDirectRelation, ViewProperty
 
 from wind_turbine.data_classes._core.query.constants import (
+    ACTUAL_INSTANCE_QUERY_LIMIT,
     NODE_PROPERTIES,
     NotSetSentinel,
     SelectedProperties,
@@ -49,6 +50,7 @@ class QueryBuildStep:
         view_id: The view ID representing the view to query.
         max_retrieve_limit: The maximum number of instances to retrieve. Defaults to -1. If set to -1, it will
             continue to retrieve instances until there are no more instances to retrieve.
+        max_retrieve_batch_limit: The maximum number of instances to retrieve in a single batch. Defaults to -1.
         select: The selected properties to retrieve. If not set, it will default to all properties. None indicates
             to not retrieve any properties from the view.
         raw_filter: This is the same filter as the expression, but without the HasData filter. This is used to count
@@ -70,6 +72,7 @@ class QueryBuildStep:
         expression: dm.query.ResultSetExpression,
         view_id: dm.ViewId | None = None,
         max_retrieve_limit: int = -1,
+        max_retrieve_batch_limit: int | None = None,
         select: dm.query.Select | None | type[NotSetSentinel] = NotSetSentinel,
         raw_filter: dm.Filter | None = None,
         connection_type: Literal["reverse-list"] | None = None,
@@ -80,6 +83,7 @@ class QueryBuildStep:
         self.expression = expression
         self.view_id = view_id
         self.max_retrieve_limit = max_retrieve_limit
+        self._max_retrieve_batch_limit = max_retrieve_batch_limit
         self.select: dm.query.Select | None
         if select is NotSetSentinel:
             try:
@@ -127,6 +131,12 @@ class QueryBuildStep:
     @property
     def is_unlimited(self) -> bool:
         return self.max_retrieve_limit in {None, -1, math.inf}
+
+    @property
+    def max_retrieve_batch_limit(self) -> int:
+        if self._max_retrieve_batch_limit is None or self._max_retrieve_batch_limit in {-1, math.inf}:
+            return ACTUAL_INSTANCE_QUERY_LIMIT
+        return max(1, min(self._max_retrieve_batch_limit, ACTUAL_INSTANCE_QUERY_LIMIT))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name={self.name!r}, from={self.from_!r})"
@@ -223,6 +233,7 @@ class QueryBuildStepFactory:
         sort: list[dm.InstanceSort] | None = None,
         limit: int | None = None,
         has_container_fields: bool = True,
+        max_retrieve_batch_limit: int | None = None,
     ) -> QueryBuildStep:
         if self._root_properties:
             skip = NODE_PROPERTIES | set(self.reverse_properties.keys())
@@ -246,6 +257,7 @@ class QueryBuildStepFactory:
             view_id=self._view_id,
             max_retrieve_limit=-1 if limit is None else limit,
             raw_filter=filter,
+            max_retrieve_batch_limit=max_retrieve_batch_limit,
         )
 
     def from_connection(

--- a/tests/test_unit/test_resulting_sdk/test_iterate.py
+++ b/tests/test_unit/test_resulting_sdk/test_iterate.py
@@ -1,0 +1,51 @@
+from cognite.client.data_classes.aggregations import AggregatedNumberedValue
+from cognite.client.data_classes.data_modeling import Node, NodeListWithCursor
+from cognite.client.data_classes.data_modeling.instances import Properties
+from cognite.client.data_classes.data_modeling.query import Query, QueryResult
+from cognite.client.testing import monkeypatch_cognite_client
+from omni import OmniClient
+from omni import data_classes as odc
+
+
+class TestIterateMethod:
+    def test_api_call_chunk_size_limit(self) -> None:
+        def query_call(query: Query) -> QueryResult:
+            assert "0" in query.with_
+            assert query.with_["0"].limit == 1
+            return self.single_item_a_result
+
+        with monkeypatch_cognite_client() as client:
+            client.data_modeling.instances.aggregate.return_value = AggregatedNumberedValue("externalId", 4)
+            client.data_modeling.instances.query.side_effect = query_call
+            pygen = OmniClient(client)
+
+        for _ in pygen.connection_item_a.iterate(chunk_size=1, limit=2):
+            ...
+
+        assert client.data_modeling.instances.query.call_count == 2
+
+    single_item_a_result = QueryResult(
+        {
+            "0": NodeListWithCursor(
+                [
+                    Node(
+                        space="my_instances",
+                        external_id="my_instance",
+                        version=42,
+                        last_updated_time=1,
+                        created_time=0,
+                        deleted_time=None,
+                        type=None,
+                        properties=Properties(
+                            {
+                                odc.ConnectionItemA._view_id: {
+                                    "name": "Item A",
+                                }
+                            }
+                        ),
+                    )
+                ],
+                cursor="abc",
+            )
+        }
+    )


### PR DESCRIPTION
# Description

**REVIEWER**: This is a +100 line code change (50 lines changed + 50 line tests) the remaining 300 lines are generated (everything inside /examples). The last commit contains the generated code.

This is part 1 of preparing for returning and accepting cursor as an argument for the iterate method. It is needed as each batch call/iteratoin must return a set of cursors that can be used for the next iterations. That cannot be done when the chunking is done on the client side as it is today.

Found 2 small unrelated bugs in the refactoring, see comments in the code. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Changed

- In the `.iterate()` method, Pygen now uses the `chunk_size` to set the max limit in the request size. For example, if `chunk_size=100` and `limit=1000`, then Pygen will now do 10 requests with size 100 instead of one with 1000 and chunk it on the client side. 

### Fixed

- Pygen will now print a warning if it reduces the batch size when executing large queries. This can happen in the generated `.list/select/retrieve/iterate()` methods.
