### PR TITLE
[PYG-376] 👹 Include version in wheel

### DIFF
--- a/cognite/pygen/_build.py
+++ b/cognite/pygen/_build.py
@@ -95,7 +95,8 @@ def build_wheel(
         config=config,
     )
 
-    generate_pyproject_toml(build_dir, top_level_package)
+    version = data_model.version if isinstance(data_model, dm.DataModel) else data_model[0].version
+    generate_pyproject_toml(build_dir, top_level_package, version=version)
 
     output_dir.mkdir(exist_ok=True, parents=True)
     ProjectBuilder(build_dir).build(distribution="wheel", output_directory=str(output_dir))
@@ -103,12 +104,12 @@ def build_wheel(
     print(f"Generated SDK wheel at {output_dir}")
 
 
-def generate_pyproject_toml(build_dir: Path, package_name: str) -> None:
+def generate_pyproject_toml(build_dir: Path, package_name: str, version: str) -> None:
     pyproject_toml = build_dir / "pyproject.toml"
     pyproject_toml.write_text(
         f"""[project]
 name = "{package_name}"
-version = "1.0.0"
+version = "{version}"
 dependencies = [
     "cognite-sdk>={cognite_sdk_version}",
     "pydantic>={PYDANTIC_VERSION}",

--- a/tests/test_unit_slow/test_generator/test_build.py
+++ b/tests/test_unit_slow/test_generator/test_build.py
@@ -15,7 +15,7 @@ def test_build_wheel() -> None:
     data_model = OMNI_SDK.load_data_model()
     local_dir = Path(__file__).parent / "dist"
     build_wheel(data_model, top_level_package="omni_sdk", output_dir=local_dir)
-    expected_file = local_dir / "omni_sdk-1.0.0-py3-none-any.whl"
+    expected_file = local_dir / f"omni_sdk-{data_model.version}-py3-none-any.whl"
     assert expected_file.exists()
 
     # Clean up


### PR DESCRIPTION
# Description

See changelog

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When calling the `build_wheel` method, the resulting wheel will now have the data model version in the filename.