### PR TITLE
[PYG-366] 🫡 Newline in doctring of typed SDKs

### DIFF
--- a/cognite/pygen/_core/templates/typed_classes.py.jinja
+++ b/cognite/pygen/_core/templates/typed_classes.py.jinja
@@ -53,6 +53,7 @@ class {{ cls.read_name }}Apply({{ cls.typed_properties_name }}, {{ cls.typed_wri
     {{ cls.description }}
 
     {% endif %}
+
     Args:
         space: The space where the node is located.
         external_id: The external id of the {{ cls.doc_name }}.
@@ -106,6 +107,7 @@ class {{ cls.read_name }}({{ cls.typed_properties_name }}, {{ cls.typed_read_bas
     {{ cls.description }}
 
     {% endif %}
+
     Args:
         space: The space where the node is located.
         external_id: The external id of the {{ cls.doc_name }}.
@@ -187,6 +189,7 @@ class {{ cls.read_name }}Apply({{ cls.typed_properties_name }}, {{ cls.typed_wri
     {{ cls.description }}
 
     {% endif %}
+
     Args:
         space: The space where the node is located.
         external_id: The external id of the {{ cls.doc_name }}.
@@ -240,6 +243,7 @@ class {{ cls.read_name }}({{ cls.typed_properties_name }}, {{ cls.typed_read_bas
     {{ cls.description }}
 
     {% endif %}
+
     Args:
         space: The space where the node is located.
         external_id: The external id of the {{ cls.doc_name }}.


### PR DESCRIPTION
# Description

Esthetic fix, ensures a newline before arguments when generating TypedSDK. Note this functionality is not exposed, those not triggering a new release. 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

