### PR TITLE
ci: fix ci

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           uv sync --all-extras
       - name: Linting and static code checks
-        run: pre-commit run --all-files
+        run: uv run pre-commit run --all-files
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Just a missing `uv run` after the switch from `poerty` to `uv`.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip

