### PR TITLE
[PYG-385] 😦 Unexpected retrieve behavior

### DIFF
--- a/cognite/pygen/_core/models/data_classes.py
+++ b/cognite/pygen/_core/models/data_classes.py
@@ -346,20 +346,20 @@ class DataClass:
     def __iter__(self) -> Iterator[Field]:
         return iter(self.fields)
 
-    def non_parent_fields(self, fields: Iterator[Field] | None = None) -> Iterator[Field]:
-        """Return all fields that are not inherited from a parent."""
-        parent_fields = {field.prop_name for parent in self.implements for field in parent}
-        return (field for field in fields or self if field.prop_name not in parent_fields)
+    def this_class_fields(self, fields: Iterator[Field] | None = None) -> Iterator[Field]:
+        """Return all fields that are not intherited or overridden from parent classes."""
+        parent_fields = {(field.prop_name, field.as_read_type_hint()) for parent in self.implements for field in parent}
+        return (field for field in fields or self if (field.prop_name, field.as_read_type_hint()) not in parent_fields)
 
     @property
     def read_fields(self) -> Iterator[Field]:
         """These fields are used when creating the read data class."""
-        return self.non_parent_fields()
+        return self.this_class_fields()
 
     @property
     def write_fields(self) -> Iterator[Field]:
         """These fields are used when creating the write data class."""
-        return (field for field in self.non_parent_fields() if field.is_write_field)
+        return (field for field in self.this_class_fields() if field.is_write_field)
 
     @property
     def write_connection_fields(self) -> Iterator[BaseConnectionField]:

--- a/cognite/pygen/_core/models/data_classes.py
+++ b/cognite/pygen/_core/models/data_classes.py
@@ -346,7 +346,7 @@ class DataClass:
     def __iter__(self) -> Iterator[Field]:
         return iter(self.fields)
 
-    def this_class_fields(self, fields: Iterator[Field] | None = None) -> Iterator[Field]:
+    def non_inherited_and_overwritten_fields(self, fields: Iterator[Field] | None = None) -> Iterator[Field]:
         """Return all fields that are not intherited or overridden from parent classes."""
         parent_fields = {(field.prop_name, field.as_read_type_hint()) for parent in self.implements for field in parent}
         return (field for field in fields or self if (field.prop_name, field.as_read_type_hint()) not in parent_fields)
@@ -354,12 +354,12 @@ class DataClass:
     @property
     def read_fields(self) -> Iterator[Field]:
         """These fields are used when creating the read data class."""
-        return self.this_class_fields()
+        return self.non_inherited_and_overwritten_fields()
 
     @property
     def write_fields(self) -> Iterator[Field]:
         """These fields are used when creating the write data class."""
-        return (field for field in self.this_class_fields() if field.is_write_field)
+        return (field for field in self.non_inherited_and_overwritten_fields() if field.is_write_field)
 
     @property
     def write_connection_fields(self) -> Iterator[BaseConnectionField]:

--- a/examples/cognite_core/data_classes/_cognite_360_image_annotation.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_annotation.py
@@ -203,6 +203,7 @@ class Cognite360ImageAnnotation(CogniteAnnotation):
 
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "Cognite360ImageAnnotation", "v1")
     space: str = DEFAULT_INSTANCE_SPACE
+    end_node: Union[Cognite360Image, str, dm.NodeId] = Field(alias="endNode") # type: ignore[assignment]
     format_version: Optional[str] = Field(None, alias="formatVersion")
     polygon: Optional[list[float]] = None
 
@@ -283,6 +284,7 @@ class Cognite360ImageAnnotationWrite(CogniteAnnotationWrite):
     _validate_end_node = _validate_end_node
 
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "Cognite360ImageAnnotation", "v1")
+    end_node: Union[Cognite360ImageWrite, str, dm.NodeId] = Field(alias="endNode") # type: ignore[assignment]
     format_version: Optional[str] = Field(None, alias="formatVersion")
     polygon: Optional[list[float]] = None
 

--- a/examples/cognite_core/data_classes/_cognite_360_image_collection.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_collection.py
@@ -157,6 +157,7 @@ class Cognite360ImageCollection(CogniteDescribableNode, Cognite3DRevision, prote
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "Cognite360ImageCollection", "v1")
 
     node_type: Union[dm.DirectRelationReference, None] = None
+    model_3d: Union[Cognite360ImageModel, str, dm.NodeId, None] = Field(default=None, repr=False, alias="model3D")
 
     @field_validator("model_3d", mode="before")
     @classmethod
@@ -202,6 +203,17 @@ class Cognite360ImageCollectionWrite(CogniteDescribableNodeWrite, Cognite3DRevis
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "Cognite360ImageCollection", "v1")
 
     node_type: Union[dm.DirectRelationReference, dm.NodeId, tuple[str, str], None] = None
+    model_3d: Union[Cognite360ImageModelWrite, str, dm.NodeId, None] = Field(default=None, repr=False, alias="model3D")
+
+    @field_validator("model_3d", mode="before")
+    def as_node_id(cls, value: Any) -> Any:
+        if isinstance(value, dm.DirectRelationReference):
+            return dm.NodeId(value.space, value.external_id)
+        elif isinstance(value, tuple) and len(value) == 2 and all(isinstance(item, str) for item in value):
+            return dm.NodeId(value[0], value[1])
+        elif isinstance(value, list):
+            return [cls.as_node_id(item) for item in value]
+        return value
 
 
 class Cognite360ImageCollectionList(DomainModelList[Cognite360ImageCollection]):

--- a/examples/cognite_core/data_classes/_cognite_cad_revision.py
+++ b/examples/cognite_core/data_classes/_cognite_cad_revision.py
@@ -142,6 +142,7 @@ class CogniteCADRevision(Cognite3DRevision, protected_namespaces=()):
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "CogniteCADRevision", "v1")
 
     node_type: Union[dm.DirectRelationReference, None] = None
+    model_3d: Union[CogniteCADModel, str, dm.NodeId, None] = Field(default=None, repr=False, alias="model3D")
     revision_id: Optional[int] = Field(None, alias="revisionId")
 
     @field_validator("model_3d", mode="before")
@@ -182,7 +183,18 @@ class CogniteCADRevisionWrite(Cognite3DRevisionWrite, protected_namespaces=()):
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "CogniteCADRevision", "v1")
 
     node_type: Union[dm.DirectRelationReference, dm.NodeId, tuple[str, str], None] = None
+    model_3d: Union[CogniteCADModelWrite, str, dm.NodeId, None] = Field(default=None, repr=False, alias="model3D")
     revision_id: Optional[int] = Field(None, alias="revisionId")
+
+    @field_validator("model_3d", mode="before")
+    def as_node_id(cls, value: Any) -> Any:
+        if isinstance(value, dm.DirectRelationReference):
+            return dm.NodeId(value.space, value.external_id)
+        elif isinstance(value, tuple) and len(value) == 2 and all(isinstance(item, str) for item in value):
+            return dm.NodeId(value[0], value[1])
+        elif isinstance(value, list):
+            return [cls.as_node_id(item) for item in value]
+        return value
 
 
 class CogniteCADRevisionList(DomainModelList[CogniteCADRevision]):

--- a/examples/cognite_core/data_classes/_cognite_point_cloud_revision.py
+++ b/examples/cognite_core/data_classes/_cognite_point_cloud_revision.py
@@ -142,6 +142,7 @@ class CognitePointCloudRevision(Cognite3DRevision, protected_namespaces=()):
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "CognitePointCloudRevision", "v1")
 
     node_type: Union[dm.DirectRelationReference, None] = None
+    model_3d: Union[CognitePointCloudModel, str, dm.NodeId, None] = Field(default=None, repr=False, alias="model3D")
     revision_id: Optional[int] = Field(None, alias="revisionId")
 
     @field_validator("model_3d", mode="before")
@@ -182,7 +183,20 @@ class CognitePointCloudRevisionWrite(Cognite3DRevisionWrite, protected_namespace
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("cdf_cdm", "CognitePointCloudRevision", "v1")
 
     node_type: Union[dm.DirectRelationReference, dm.NodeId, tuple[str, str], None] = None
+    model_3d: Union[CognitePointCloudModelWrite, str, dm.NodeId, None] = Field(
+        default=None, repr=False, alias="model3D"
+    )
     revision_id: Optional[int] = Field(None, alias="revisionId")
+
+    @field_validator("model_3d", mode="before")
+    def as_node_id(cls, value: Any) -> Any:
+        if isinstance(value, dm.DirectRelationReference):
+            return dm.NodeId(value.space, value.external_id)
+        elif isinstance(value, tuple) and len(value) == 2 and all(isinstance(item, str) for item in value):
+            return dm.NodeId(value[0], value[1])
+        elif isinstance(value, list):
+            return [cls.as_node_id(item) for item in value]
+        return value
 
 
 class CognitePointCloudRevisionList(DomainModelList[CognitePointCloudRevision]):


### PR DESCRIPTION
# Description

**Reviewer** 12 lines code fix, rest is test data.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When generating an SDK with views that overwrites parent properties, `pygen` now includes the overwritten field in the child classes. For example, if you have a `Batch` view that implements `CogniteActivity` and overwrites the `assets` property to be of value type  `MyAsset`, `pygen` will now retrieve `MyAsset`s instead of `CogniteAsset`.
