### PR TITLE
ci: fix twine upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload --skip-existing --verbose dist/*
+        run: uv run twine upload --skip-existing --verbose dist/*
 
       - name: Add entry to CHANGELOG
         if: env.version != '0.0.0'


### PR DESCRIPTION
# Description

Bug in ci so repeating last PR changelog and bump  to get it released.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When generating an SDK with views that overwrites parent properties, `pygen` now includes the overwritten field in the child classes. For example, if you have a `Batch` view that implements `CogniteActivity` and overwrites the `assets` property to be of value type  `MyAsset`, `pygen` will now retrieve `MyAsset`s instead of `CogniteAsset`.
