### PR TITLE
Fix invalid generated SDK when property has name 'properties'

### DIFF
--- a/cognite/pygen/_core/models/filter_methods.py
+++ b/cognite/pygen/_core/models/filter_methods.py
@@ -171,6 +171,10 @@ class FilterMethod:
     parameters: list[FilterParameter]
     implementations: list[FilterImplementation]
 
+    @property
+    def parameters_list(self):
+        return [p.name for p in self.parameters]
+
     @classmethod
     def from_fields(
         cls,

--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -181,7 +181,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
     def search(
         self,
         query: str,
-        properties: {{ data_class.text_field_names }} | SequenceNotStr[{{ data_class.text_field_names }}] | None = None,
+        {{ 'properties' if 'properties' not in list_method.parameters_list else 'parameters_'}}: {{ data_class.text_field_names }} | SequenceNotStr[{{ data_class.text_field_names }}] | None = None,
         {% for parm in list_method.parameters %}
         {{ parm.name }}: {{ parm.annotation }} = {{ parm.default }},
         {% endfor %}

--- a/tests/data/models/OmniSub/model.yaml
+++ b/tests/data/models/OmniSub/model.yaml
@@ -88,6 +88,22 @@ views:
       defaultValue: null
       name: selfDirect
       description: null
+    properties:
+      container:
+        space: sp_pygen_models
+        externalId: ConnectionBase
+      containerPropertyIdentifier: properties
+      type:
+        list: false
+        collation: ucs_basic
+        type: text
+      nullable: true
+      immutable: false
+      autoIncrement: false
+      source: null
+      defaultValue: null
+      name: name
+      description: null
   lastUpdatedTime: 1729345477397
   createdTime: 1729345477397
 - space: sp_pygen_models


### PR DESCRIPTION
# Description
For the `search` function, replace argumnet `properties` with `properties_` if there is property in the view with name `properties`.
Currently this case makes an invalid SDK with dual `properties` arguments.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed
- When a view has a property with name `properties`, the `properties` argument in the search function has been renamed to `properties_`.