### PR TITLE
➡New owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @cognitedata/iknow
-
+* @cognitedata/partner-enablement @cognitedata/atlas-ai-team


### PR DESCRIPTION
# Description

Transfer the pygen repo from the `iknow` team to the `partner-enablement` and `atlas-ai` teams.

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
