### PR TITLE
[PYG-407] 🐜As write fails for CDF external references.

### DIFF
--- a/cognite/pygen/_core/templates/data_classes_core_base.py.jinja
+++ b/cognite/pygen/_core/templates/data_classes_core_base.py.jinja
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,

--- a/cognite/pygen/_core/templates/data_classes_core_base.py.jinja
+++ b/cognite/pygen/_core/templates/data_classes_core_base.py.jinja
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -942,6 +945,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/cognite_core/_api/cognite_360_image_model.py
+++ b/examples/cognite_core/_api/cognite_360_image_model.py
@@ -463,7 +463,7 @@ class Cognite360ImageModelAPI(
             builder.extend(
                 factory.from_reverse_relation(
                     Cognite360ImageCollection._view_id,
-                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1"), "model3D"),
+                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "Cognite360ImageCollection", "v1"), "model3D"),
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "collections"),
                     has_container_fields=True,

--- a/examples/cognite_core/_api/cognite_cad_model.py
+++ b/examples/cognite_core/_api/cognite_cad_model.py
@@ -461,7 +461,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteCADRevision._view_id,
-                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1"), "model3D"),
+                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "CogniteCADRevision", "v1"), "model3D"),
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "revisions"),
                     has_container_fields=True,

--- a/examples/cognite_core/_api/cognite_point_cloud_model.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_model.py
@@ -475,7 +475,7 @@ class CognitePointCloudModelAPI(
             builder.extend(
                 factory.from_reverse_relation(
                     CognitePointCloudRevision._view_id,
-                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1"), "model3D"),
+                    through=dm.PropertyId(dm.ViewId("cdf_cdm", "CognitePointCloudRevision", "v1"), "model3D"),
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "revisions"),
                     has_container_fields=True,

--- a/examples/cognite_core/data_classes/_cognite_360_image_model.py
+++ b/examples/cognite_core/data_classes/_cognite_360_image_model.py
@@ -347,7 +347,7 @@ class _Cognite360ImageModelQuery(NodeQueryCore[T_DomainModelList, Cognite360Imag
                 client,
                 result_list_cls,
                 dm.query.NodeResultSetExpression(
-                    through=dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1").as_property_ref("model3D"),
+                    through=dm.ViewId("cdf_cdm", "Cognite360ImageCollection", "v1").as_property_ref("model3D"),
                     direction="inwards",
                 ),
                 connection_name="collections",

--- a/examples/cognite_core/data_classes/_cognite_cad_model.py
+++ b/examples/cognite_core/data_classes/_cognite_cad_model.py
@@ -339,7 +339,7 @@ class _CogniteCADModelQuery(NodeQueryCore[T_DomainModelList, CogniteCADModelList
                 client,
                 result_list_cls,
                 dm.query.NodeResultSetExpression(
-                    through=dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1").as_property_ref("model3D"),
+                    through=dm.ViewId("cdf_cdm", "CogniteCADRevision", "v1").as_property_ref("model3D"),
                     direction="inwards",
                 ),
                 connection_name="revisions",

--- a/examples/cognite_core/data_classes/_cognite_point_cloud_model.py
+++ b/examples/cognite_core/data_classes/_cognite_point_cloud_model.py
@@ -347,7 +347,7 @@ class _CognitePointCloudModelQuery(NodeQueryCore[T_DomainModelList, CognitePoint
                 client,
                 result_list_cls,
                 dm.query.NodeResultSetExpression(
-                    through=dm.ViewId("cdf_cdm", "Cognite3DRevision", "v1").as_property_ref("model3D"),
+                    through=dm.ViewId("cdf_cdm", "CognitePointCloudRevision", "v1").as_property_ref("model3D"),
                     direction="inwards",
                 ),
                 connection_name="revisions",

--- a/examples/cognite_core/data_classes/_core/base.py
+++ b/examples/cognite_core/data_classes/_core/base.py
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -920,6 +923,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/cognite_core/data_classes/_core/base.py
+++ b/examples/cognite_core/data_classes/_core/base.py
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,

--- a/examples/omni/data_classes/_core/base.py
+++ b/examples/omni/data_classes/_core/base.py
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -920,6 +923,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/omni/data_classes/_core/base.py
+++ b/examples/omni/data_classes/_core/base.py
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,

--- a/examples/omni_multi/data_classes/_core/base.py
+++ b/examples/omni_multi/data_classes/_core/base.py
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -898,6 +901,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/omni_multi/data_classes/_core/base.py
+++ b/examples/omni_multi/data_classes/_core/base.py
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,

--- a/examples/omni_sub/data_classes/_core/base.py
+++ b/examples/omni_sub/data_classes/_core/base.py
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -898,6 +901,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/omni_sub/data_classes/_core/base.py
+++ b/examples/omni_sub/data_classes/_core/base.py
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,

--- a/examples/wind_turbine/data_classes/_core/base.py
+++ b/examples/wind_turbine/data_classes/_core/base.py
@@ -25,10 +25,13 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
+    TimeSeries,
     TimeSeriesWrite,
     TimeSeriesWriteList,
+    FileMetadata,
     FileMetadataWrite,
     FileMetadataWriteList,
+    Sequence as CogniteSequence,
     SequenceWrite,
     SequenceWriteList,
     TimeSeriesList,
@@ -920,6 +923,8 @@ def as_write_value(value: Any) -> Any:
         return as_write_args(value)
     elif isinstance(value, Sequence) and not isinstance(value, str):
         return [as_write_value(item) for item in value]
+    elif isinstance(value, TimeSeries | FileMetadata | CogniteSequence):
+        return value.as_write()
     return value
 
 

--- a/examples/wind_turbine/data_classes/_core/base.py
+++ b/examples/wind_turbine/data_classes/_core/base.py
@@ -25,18 +25,18 @@ from typing import (
 import pandas as pd
 from cognite.client import data_modeling as dm
 from cognite.client.data_classes import (
-    TimeSeries,
-    TimeSeriesWrite,
-    TimeSeriesWriteList,
     FileMetadata,
+    FileMetadataList,
     FileMetadataWrite,
     FileMetadataWriteList,
     Sequence as CogniteSequence,
+    SequenceList,
     SequenceWrite,
     SequenceWriteList,
+    TimeSeries,
     TimeSeriesList,
-    FileMetadataList,
-    SequenceList,
+    TimeSeriesWrite,
+    TimeSeriesWriteList,
 )
 from cognite.client.data_classes.data_modeling.instances import (
     Instance,


### PR DESCRIPTION
# Description

The current as write logic fails to account for TimeSeries/FileMetadata/Sequence references in the view.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- In the generated SDK, the `.as_write(...)` field no longer fails for data classes that uses CDF external reference fields. 
