### PR TITLE
[PYG-368, PYG-369] 🦟Upsert direct relations references

### DIFF
--- a/examples/cognite_core/data_classes/_core/base.py
+++ b/examples/cognite_core/data_classes/_core/base.py
@@ -761,22 +761,23 @@ def serialize_properties(model: DomainModelWrite | DomainRelationWrite, resource
     properties: dict[str, Any] = {}
     model_fields = type(model).model_fields
     for field_name in model._container_fields:
-        if field_name in model.model_fields_set:
-            value = getattr(model, field_name)
-            key = model_fields[field_name].alias or field_name
-            if field_name in model._direct_relations:
-                properties[key] = serialize_relation(value, model.space)
-            else:
-                properties[key] = serialize_property(value)
+        if field_name not in model.model_fields_set:
+            continue
+        value = getattr(model, field_name)
+        key = model_fields[field_name].alias or field_name
+        if field_name in model._direct_relations:
+            properties[key] = serialize_relation(value, model.space)
+        else:
+            properties[key] = serialize_property(value)
 
-            values = value if isinstance(value, Sequence) else [value]
-            for item in values:
-                if isinstance(item, FileMetadataWrite):
-                    resources.files.append(item)
-                elif isinstance(item, TimeSeriesWrite):
-                    resources.time_series.append(item)
-                elif isinstance(item, SequenceWrite):
-                    resources.sequences.append(item)
+        values = value if isinstance(value, Sequence) and not isinstance(value, str) else [value]
+        for item in values:
+            if isinstance(item, FileMetadataWrite):
+                resources.files.append(item)
+            elif isinstance(item, TimeSeriesWrite):
+                resources.time_series.append(item)
+            elif isinstance(item, SequenceWrite):
+                resources.sequences.append(item)
 
     return properties
 

--- a/tests/test_integration/test_upsert.py
+++ b/tests/test_integration/test_upsert.py
@@ -374,6 +374,6 @@ def test_upsert_parent_direct_relation(core_client: CogniteCoreClient, omni_tmp_
         assert len(child_nodes) == 1
         child_node = child_nodes[0]
 
-        assert child_node.properties[view_id].get("parent") == parent.as_id()
+        assert child_node.properties[view_id].get("parent") == parent.as_id().dump(include_instance_type=False)
     finally:
         core_client.delete([parent.as_id(), child.as_id()])


### PR DESCRIPTION
# Description

Status: I have been unable to recreate this one. Currently awaiting more information from user reporting issue. 

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- In the generated SDK, calling `.upsert` with a direct relation now successfully populates the direct relation property in the node.
