### PR TITLE
[PYG-410] 🐛As write maintain view

### DIFF
--- a/tests/test_unit/test_resulting_sdk/test_data_class.py
+++ b/tests/test_unit/test_resulting_sdk/test_data_class.py
@@ -284,3 +284,40 @@ class TestAsWrite:
         assert isinstance(write.file, FileMetadataWrite)
         assert isinstance(write.sequence, SequenceWrite)
         assert isinstance(write.timeseries, TimeSeriesWrite)
+
+    def test_as_write_maintain_view_type(self) -> None:
+        now = datetime.now(timezone.utc)
+        record = dc.DataRecord(
+            version=1,
+            last_updated_time=now,
+            created_time=now,
+            deleted_time=None,
+        )
+        read = dc.ConnectionItemH(
+            external_id="test_as_write_maintain_view_type",
+            name="ConnectionH",
+            data_record=record,
+            direct_parent_single=dc.Implementation1(
+                external_id="test_as_write_maintain_view_type:Implementation1",
+                main_value="main_value",
+                value_1="value_1",
+                value_2="value_2",
+                data_record=record,
+            ),
+            direct_parent_multi=[
+                dc.Implementation2(
+                    external_id="test_as_write_maintain_view_type:Implementation2",
+                    main_value="main_value",
+                    sub_value="sub_value",
+                    data_record=record,
+                )
+            ],
+        )
+
+        write = read.as_write()
+
+        assert isinstance(write, dc.ConnectionItemHWrite)
+        assert isinstance(write.direct_parent_single, dc.Implementation1Write)
+        assert isinstance(write.direct_parent_single, list)
+        assert len(write.direct_parent_multi) == 1
+        assert isinstance(write.direct_parent_multi[0], dc.Implementation2Write)


### PR DESCRIPTION
# Description

**Reviewer**: All code inside `examples/` is generated. 



## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When calling `.as_write()` on class with direct relations to a 'parent' view. The view type is maintained. For example, if I have a data model with `MyAsset` view that implements `CogniteAsset`, and I have a `MyFile` view that has a direct relation property named `asset` with type `CogniteAsset`. Then, if I have an instance of `MyFile` with the asset property set to an instance of `MyAsset`, then after calling `.as_write()` on `MyFile` I will now have a `MyFileWrite` which has the `asset` property set to an instance of `MyAssetWrite` instead of `CogniteAssetWrite`.