### PR TITLE
[PYG-413]  Unexpected property

### DIFF
--- a/cognite/pygen/_query/processing.py
+++ b/cognite/pygen/_query/processing.py
@@ -264,6 +264,8 @@ class QueryUnpacker:
 
         """
         dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/cognite/pygen/_query/processing.py
+++ b/cognite/pygen/_query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,7 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/examples/cognite_core/data_classes/_core/query/processing.py
+++ b/examples/cognite_core/data_classes/_core/query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,9 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/examples/omni/data_classes/_core/query/processing.py
+++ b/examples/omni/data_classes/_core/query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,9 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/examples/omni_multi/data_classes/_core/query/processing.py
+++ b/examples/omni_multi/data_classes/_core/query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,9 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/examples/omni_sub/data_classes/_core/query/processing.py
+++ b/examples/omni_sub/data_classes/_core/query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,9 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")

--- a/examples/wind_turbine/data_classes/_core/query/processing.py
+++ b/examples/wind_turbine/data_classes/_core/query/processing.py
@@ -242,7 +242,7 @@ class QueryUnpacker:
     @classmethod
     def flatten_dump(
         cls,
-        node: dm.Node | dm.Edge,
+        instance: Instance,
         selected_properties: set[str] | None,
         direct_property: str | None = None,
         as_data_record: bool = False,
@@ -251,7 +251,7 @@ class QueryUnpacker:
         """Dumps the node/edge into a flat dictionary.
 
         Args:
-            node: The node or edge to dump.
+            instance: The node or edge to dump.
             selected_properties: The properties to include in the dump. If None, all properties are included.
             direct_property: Assumed to be the property ID of a direct relation. If present, the value
                 of this property will be converted to a NodeId or a list of NodeIds. The motivation for this is
@@ -263,7 +263,9 @@ class QueryUnpacker:
             A dictionary with the properties of the node or edge
 
         """
-        dumped = node.dump()
+        dumped = instance.dump()
+        # Remove the instanceType as we already have the context of the instance type
+        dumped.pop("instanceType", None)
         dumped_properties = dumped.pop("properties", {})
         if "type" in dumped:
             dumped[type_key] = dumped.pop("type")


### PR DESCRIPTION
# Description

**Reviewer**: All code inside `examples/` is generated.

Pygen response DTO object (data transfer objects) allow extra properties to be forward compatible with changes in the data model. However, the user gets surprised when `instanceType` is set on the object. This PR removes it.


## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When calling `.list()` or `.retrieve()`  with `retrieve_connection=full` , `instanceType` is no longer set on the response items.
