### PR TITLE
feat: add instance_types parameter to QueryExecutor

### DIFF
--- a/cognite/pygen/_query/interface.py
+++ b/cognite/pygen/_query/interface.py
@@ -98,8 +98,7 @@ class QueryExecutor:
         view = self._get_view(view_id)
         flatten_props, are_flat_properties = self._as_property_list(properties, "list") if properties else (None, False)
         if properties is None or are_flat_properties:
-            if instance_types is None:
-                instance_types = self._get_instance_types(view)
+            instance_types = instance_types or self._get_instance_types(view)
             all_results: list[dict[str, Any]] = []
             for instance_type in instance_types:
                 # The .search has 4 overloads methods and MyPy seems to just give up:
@@ -294,8 +293,7 @@ class QueryExecutor:
 
         if not factory.connection_properties:
             list_results: list[dict[str, Any]] = []
-            if instance_types is None:
-                instance_types = self._get_instance_types(view)
+            instance_types = instance_types or self._get_instance_types(view)
             for instance_type in instance_types:
                 response = self._client.data_modeling.instances.list(
                     instance_type=instance_type,
@@ -358,8 +356,7 @@ class QueryExecutor:
             raise ValueError("Cannot mix metric and histogram aggregations")
 
         view = self._get_view(view_id)
-        if instance_types is None:
-            instance_types = self._get_instance_types(view)
+        instance_types = instance_types or self._get_instance_types(view)
         if metric_aggregates and group_by is not None:
             if len(instance_types) == 2 and any(isinstance(agg, Avg) for agg in metric_aggregates):
                 # This can be supported (need to add the count of the values to the AvgValue, but will postpone

--- a/cognite/pygen/_query/interface.py
+++ b/cognite/pygen/_query/interface.py
@@ -55,6 +55,7 @@ class QueryExecutor:
         search_properties: str | SequenceNotStr[str] | None = None,
         sort: Sequence[dm.InstanceSort] | dm.InstanceSort | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> list[dict[str, Any]]:
         """Search for nodes/edges in a view.
 
@@ -70,6 +71,7 @@ class QueryExecutor:
             search_properties: The properties to search. If None, all text properties are searched.
             sort: The sort order of the results.
             limit: The maximum number of results to return. Max 1000.
+            instance_types: The instance types to search. If None, defaults to the view's supported types.
 
         Returns:
             list[dict[str, Any]]: The search results.
@@ -80,7 +82,7 @@ class QueryExecutor:
 
         """
         filter = self._equals_none_to_not_exists(filter)
-        return self._execute_search(view, properties, query, filter, search_properties, sort, limit)
+        return self._execute_search(view, properties, query, filter, search_properties, sort, limit, instance_types)
 
     def _execute_search(
         self,
@@ -91,11 +93,13 @@ class QueryExecutor:
         search_properties: str | SequenceNotStr[str] | None = None,
         sort: Sequence[dm.InstanceSort] | dm.InstanceSort | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> list[dict[str, Any]]:
         view = self._get_view(view_id)
         flatten_props, are_flat_properties = self._as_property_list(properties, "list") if properties else (None, False)
         if properties is None or are_flat_properties:
-            instance_types = self._get_instance_types(view)
+            if instance_types is None:
+                instance_types = self._get_instance_types(view)
             all_results: list[dict[str, Any]] = []
             for instance_type in instance_types:
                 # The .search has 4 overloads methods and MyPy seems to just give up:
@@ -172,6 +176,7 @@ class QueryExecutor:
         query: str | None = None,
         search_properties: str | SequenceNotStr[str] | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> dict[str, Any]: ...
 
     @overload
@@ -184,6 +189,7 @@ class QueryExecutor:
         query: str | None = None,
         search_properties: str | SequenceNotStr[str] | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> list[dict[str, Any]]: ...
 
     def aggregate(
@@ -195,6 +201,7 @@ class QueryExecutor:
         query: str | None = None,
         search_properties: str | SequenceNotStr[str] | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         """Aggregate nodes/edges in a view.
 
@@ -211,6 +218,7 @@ class QueryExecutor:
                 of a specific search query. It is useful for combining with the search method.
             search_properties: The properties to search. If None, all text properties are searched.
             limit: The maximum number of results to return. Max 1000.
+            instance_types: The instance types to aggregate. If None, defaults to the view's supported types.
 
         Returns:
             dict[str, Any] | list[dict[str, Any]]: The aggregation results.
@@ -220,7 +228,7 @@ class QueryExecutor:
 
         """
         filter = self._equals_none_to_not_exists(filter)
-        return self._execute_aggregation(view, aggregates, search_properties, query, filter, group_by, limit)
+        return self._execute_aggregation(view, aggregates, search_properties, query, filter, group_by, limit, instance_types)
 
     @classmethod
     def _equals_none_to_not_exists(cls, filter: filters.Filter | None) -> filters.Filter | None:
@@ -275,6 +283,7 @@ class QueryExecutor:
         filter: filters.Filter | None = None,
         sort: Sequence[dm.InstanceSort] | dm.InstanceSort | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> list[dict[str, Any]]:
         view = self._get_view(view_id)
         root_properties, _ = self._as_property_list(properties, "list")
@@ -285,7 +294,8 @@ class QueryExecutor:
 
         if not factory.connection_properties:
             list_results: list[dict[str, Any]] = []
-            instance_types = self._get_instance_types(view)
+            if instance_types is None:
+                instance_types = self._get_instance_types(view)
             for instance_type in instance_types:
                 response = self._client.data_modeling.instances.list(
                     instance_type=instance_type,
@@ -339,6 +349,7 @@ class QueryExecutor:
         filter: filters.Filter | None = None,
         group_by: str | SequenceNotStr[str] | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         aggregates_list = aggregates if isinstance(aggregates, Sequence) else [aggregates]
         metric_aggregates = [agg for agg in aggregates_list if isinstance(agg, dm.aggregations.MetricAggregation)]
@@ -347,7 +358,8 @@ class QueryExecutor:
             raise ValueError("Cannot mix metric and histogram aggregations")
 
         view = self._get_view(view_id)
-        instance_types = self._get_instance_types(view)
+        if instance_types is None:
+            instance_types = self._get_instance_types(view)
         if metric_aggregates and group_by is not None:
             if len(instance_types) == 2 and any(isinstance(agg, Avg) for agg in metric_aggregates):
                 # This can be supported (need to add the count of the values to the AvgValue, but will postpone
@@ -473,6 +485,7 @@ class QueryExecutor:
         filter: filters.Filter | None = None,
         sort: Sequence[dm.InstanceSort] | dm.InstanceSort | None = None,
         limit: int | None = None,
+        instance_types: list[Literal["node", "edge"]] | None = None,
     ) -> list[dict[str, Any]]:
         """List nodes/edges in a view.
 
@@ -486,6 +499,7 @@ class QueryExecutor:
             filter: The filter to apply ahead of the list operation.
             sort: The sort order of the results.
             limit: The maximum number of results to return. Pagination is handled automatically.
+            instance_types: The instance types to list. If None, defaults to the view's supported types.
 
         Returns:
             list[dict[str, Any]]: The list of nodes/edges in the view.
@@ -495,4 +509,4 @@ class QueryExecutor:
             CogniteAPIError: If the view is not found.
         """
         filter = self._equals_none_to_not_exists(filter)
-        return self._execute_list(view, properties, filter, sort, limit)
+        return self._execute_list(view, properties, filter, sort, limit, instance_types)

--- a/cognite/pygen/_query/interface.py
+++ b/cognite/pygen/_query/interface.py
@@ -227,7 +227,9 @@ class QueryExecutor:
 
         """
         filter = self._equals_none_to_not_exists(filter)
-        return self._execute_aggregation(view, aggregates, search_properties, query, filter, group_by, limit, instance_types)
+        return self._execute_aggregation(
+            view, aggregates, search_properties, query, filter, group_by, limit, instance_types
+        )
 
     @classmethod
     def _equals_none_to_not_exists(cls, filter: filters.Filter | None) -> filters.Filter | None:


### PR DESCRIPTION
# Description

In Atlas, we are facing the following issue: for views which are both nodes and edges, when faced with a prompt like "count the maintenance plans where createdBy is greater than 2024-01-01", we will create a query like 

```
{'operation': 'aggregate',
 'dataModelView': {'space': 'gsk_montrose_model',
  'externalId': 'GskMontroseModel',
  'version': 'v1',
  'view': 'GskMaintenancePlan'},
 'properties': ['name',
  'externalId',
  'createdTime',
  'lastUpdatedTime',
  'space'],
 'filter': {'and': [{'range': {'property': ['node', 'createdTime'],
     'gte': '2024-01-01T00:00:00'}}]}, 
 'aggregate': {"properties": {"count":  "externalId"}}
      }
```
which, when executed, will give the error 

```
Error: Unknown property: node.space | code: 400 | X-Request-ID: 66856ee8-2067-9a44-b94a-34b1c2852e8a | cluster: westeurope-1
```

The code which triggers this is https://github.com/cognitedata/pygen/blob/fee95de40d3dd317061d2187b78f9b52aeaaa827/cognite/pygen/_query/interface.py#L357-L369 

which will fail as we cannot filter on a node property when the instance type is `edge` (makes sense). 

This error pops up in a few different versions. In QKG we only query nodes, so the simplest fix for us is to be allowed to override the `instance_type` property to only include `node`. This PR makes that possible. 


## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Added

- [alpha] Pygen now allows you to override the `instance_types` property in the QueryExecutor class