### PR TITLE
[PYG-418] 🐛 Reverse identifier

### DIFF
--- a/cognite/pygen/_core/models/data_classes.py
+++ b/cognite/pygen/_core/models/data_classes.py
@@ -512,12 +512,10 @@ class DataClass:
         )
 
     @property
-    def has_direct_or_reverse_relation_with_target(self) -> bool:
+    def has_direct_relation_with_target(self) -> bool:
         """Whether the data class has any fields that are direct or reverse relations."""
         return any(
-            isinstance(field_, BaseConnectionField)
-            and (field_.is_direct_relation or field_.is_reverse_direct_relation)
-            and field_.destination_class
+            isinstance(field_, BaseConnectionField) and field_.is_direct_relation and field_.destination_class
             for field_ in self
         )
 

--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -497,6 +497,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
             )
             {% endif %}
             {% endfor %}
+        if retrieve_connections == "full":
             {% for field in data_class.fields_of_type(ft.BaseConnectionField) %}
             {% if field.is_direct_relation and field.destination_class %}
             builder.extend(

--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -473,7 +473,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
             )
         {% endif %}
         {% endfor %}
-{% if data_class.has_direct_or_reverse_relation_with_target %}
+{% if data_class.has_reverse_direct_relations %}
         if retrieve_connections in {"identifier", "full"}:
             {% for field in data_class.fields_of_type(ft.BaseConnectionField) %}
             {% if field.is_reverse_direct_relation %}
@@ -497,6 +497,8 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
             )
             {% endif %}
             {% endfor %}
+{% endif %}
+{% if data_class.has_direct_relation_with_target %}
         if retrieve_connections == "full":
             {% for field in data_class.fields_of_type(ft.BaseConnectionField) %}
             {% if field.is_direct_relation and field.destination_class %}

--- a/cognite/pygen/_core/templates/api_class_node.py.jinja
+++ b/cognite/pygen/_core/templates/api_class_node.py.jinja
@@ -474,7 +474,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
         {% endif %}
         {% endfor %}
 {% if data_class.has_direct_or_reverse_relation_with_target %}
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             {% for field in data_class.fields_of_type(ft.BaseConnectionField) %}
             {% if field.is_reverse_direct_relation %}
             builder.extend(
@@ -492,6 +492,7 @@ class {{ api_class.name }}({% if data_class.is_writable %}NodeAPI{% else %}NodeR
                 {% else %}
                 has_container_fields=False,
                 {% endif %}
+                include_properties=retrieve_connections == "full",
                 )
             )
             {% endif %}

--- a/examples/cognite_core/_api/cognite_360_image_model.py
+++ b/examples/cognite_core/_api/cognite_360_image_model.py
@@ -459,7 +459,7 @@ class Cognite360ImageModelAPI(
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Cognite360ImageCollection._view_id,
@@ -467,8 +467,10 @@ class Cognite360ImageModelAPI(
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "collections"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteFile._view_id,

--- a/examples/cognite_core/_api/cognite_3_d_object.py
+++ b/examples/cognite_core/_api/cognite_3_d_object.py
@@ -555,7 +555,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
                     edge_view=Cognite360ImageAnnotation._view_id,
                 )
             )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteAsset._view_id,
@@ -563,6 +563,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "asset"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -572,6 +573,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "cadNodes"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -581,6 +583,7 @@ class Cognite3DObjectAPI(NodeAPI[Cognite3DObject, Cognite3DObjectWrite, Cognite3
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "pointCloudVolumes"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
         return builder.build()

--- a/examples/cognite_core/_api/cognite_asset.py
+++ b/examples/cognite_core/_api/cognite_asset.py
@@ -945,7 +945,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteActivity._view_id,
@@ -953,6 +953,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "activities"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -962,6 +963,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "children"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -971,6 +973,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "equipment"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -980,6 +983,7 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "files"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -989,8 +993,10 @@ class CogniteAssetAPI(NodeAPI[CogniteAsset, CogniteAssetWrite, CogniteAssetList,
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "timeSeries"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteAssetClass._view_id,

--- a/examples/cognite_core/_api/cognite_cad_model.py
+++ b/examples/cognite_core/_api/cognite_cad_model.py
@@ -457,7 +457,7 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteCADRevision._view_id,
@@ -465,8 +465,10 @@ class CogniteCADModelAPI(NodeAPI[CogniteCADModel, CogniteCADModelWrite, CogniteC
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "revisions"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteFile._view_id,

--- a/examples/cognite_core/_api/cognite_equipment.py
+++ b/examples/cognite_core/_api/cognite_equipment.py
@@ -807,7 +807,7 @@ class CogniteEquipmentAPI(
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteActivity._view_id,
@@ -815,6 +815,7 @@ class CogniteEquipmentAPI(
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "activities"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -824,8 +825,10 @@ class CogniteEquipmentAPI(
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "timeSeries"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteAsset._view_id,

--- a/examples/cognite_core/_api/cognite_file.py
+++ b/examples/cognite_core/_api/cognite_file.py
@@ -784,7 +784,7 @@ class CogniteFileAPI(NodeAPI[CogniteFile, CogniteFileWrite, CogniteFileList, Cog
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteEquipment._view_id,
@@ -792,8 +792,10 @@ class CogniteFileAPI(NodeAPI[CogniteFile, CogniteFileWrite, CogniteFileList, Cog
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "equipment"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteAsset._view_id,

--- a/examples/cognite_core/_api/cognite_point_cloud_model.py
+++ b/examples/cognite_core/_api/cognite_point_cloud_model.py
@@ -471,7 +471,7 @@ class CognitePointCloudModelAPI(
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CognitePointCloudRevision._view_id,
@@ -479,8 +479,10 @@ class CognitePointCloudModelAPI(
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "revisions"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteFile._view_id,

--- a/examples/cognite_core/_api/cognite_time_series.py
+++ b/examples/cognite_core/_api/cognite_time_series.py
@@ -805,7 +805,7 @@ class CogniteTimeSeriesAPI(
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     CogniteActivity._view_id,
@@ -813,8 +813,10 @@ class CogniteTimeSeriesAPI(
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "activities"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     CogniteAsset._view_id,

--- a/examples/omni/_api/connection_item_e.py
+++ b/examples/omni/_api/connection_item_e.py
@@ -505,7 +505,7 @@ class ConnectionItemEAPI(NodeAPI[ConnectionItemE, ConnectionItemEWrite, Connecti
                     edge_view=ConnectionEdgeA._view_id,
                 )
             )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     ConnectionItemD._view_id,
@@ -513,6 +513,7 @@ class ConnectionItemEAPI(NodeAPI[ConnectionItemE, ConnectionItemEWrite, Connecti
                     connection_type="reverse-list",
                     connection_property=ViewPropertyId(self._view_id, "directReverseMulti"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
             builder.extend(
@@ -522,6 +523,7 @@ class ConnectionItemEAPI(NodeAPI[ConnectionItemE, ConnectionItemEWrite, Connecti
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "directReverseSingle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
         return builder.build()

--- a/examples/wind_turbine/_api/blade.py
+++ b/examples/wind_turbine/_api/blade.py
@@ -378,7 +378,7 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList, BladeWriteList]):
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     SensorPosition._view_id,
@@ -386,6 +386,7 @@ class BladeAPI(NodeAPI[Blade, BladeWrite, BladeList, BladeWriteList]):
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "sensor_positions"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
         return builder.build()

--- a/examples/wind_turbine/_api/gearbox.py
+++ b/examples/wind_turbine/_api/gearbox.py
@@ -489,7 +489,7 @@ class GearboxAPI(NodeAPI[Gearbox, GearboxWrite, GearboxList, GearboxWriteList]):
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Nacelle._view_id,
@@ -497,8 +497,10 @@ class GearboxAPI(NodeAPI[Gearbox, GearboxWrite, GearboxList, GearboxWriteList]):
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "nacelle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/generator.py
+++ b/examples/wind_turbine/_api/generator.py
@@ -436,7 +436,7 @@ class GeneratorAPI(NodeAPI[Generator, GeneratorWrite, GeneratorList, GeneratorWr
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Nacelle._view_id,
@@ -444,8 +444,10 @@ class GeneratorAPI(NodeAPI[Generator, GeneratorWrite, GeneratorList, GeneratorWr
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "nacelle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/high_speed_shaft.py
+++ b/examples/wind_turbine/_api/high_speed_shaft.py
@@ -489,7 +489,7 @@ class HighSpeedShaftAPI(NodeAPI[HighSpeedShaft, HighSpeedShaftWrite, HighSpeedSh
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Nacelle._view_id,
@@ -497,8 +497,10 @@ class HighSpeedShaftAPI(NodeAPI[HighSpeedShaft, HighSpeedShaftWrite, HighSpeedSh
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "nacelle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/main_shaft.py
+++ b/examples/wind_turbine/_api/main_shaft.py
@@ -598,7 +598,7 @@ class MainShaftAPI(NodeAPI[MainShaft, MainShaftWrite, MainShaftList, MainShaftWr
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Nacelle._view_id,
@@ -606,8 +606,10 @@ class MainShaftAPI(NodeAPI[MainShaft, MainShaftWrite, MainShaftList, MainShaftWr
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "nacelle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/nacelle.py
+++ b/examples/wind_turbine/_api/nacelle.py
@@ -873,7 +873,7 @@ class NacelleAPI(NodeAPI[Nacelle, NacelleWrite, NacelleList, NacelleWriteList]):
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     WindTurbine._view_id,
@@ -881,8 +881,10 @@ class NacelleAPI(NodeAPI[Nacelle, NacelleWrite, NacelleList, NacelleWriteList]):
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "wind_turbine"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/power_inverter.py
+++ b/examples/wind_turbine/_api/power_inverter.py
@@ -490,7 +490,7 @@ class PowerInverterAPI(NodeAPI[PowerInverter, PowerInverterWrite, PowerInverterL
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     Nacelle._view_id,
@@ -498,8 +498,10 @@ class PowerInverterAPI(NodeAPI[PowerInverter, PowerInverterWrite, PowerInverterL
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "nacelle"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/examples/wind_turbine/_api/rotor.py
+++ b/examples/wind_turbine/_api/rotor.py
@@ -435,7 +435,7 @@ class RotorAPI(NodeAPI[Rotor, RotorWrite, RotorList, RotorWriteList]):
                 has_container_fields=True,
             )
         )
-        if retrieve_connections == "full":
+        if retrieve_connections in {"identifier", "full"}:
             builder.extend(
                 factory.from_reverse_relation(
                     WindTurbine._view_id,
@@ -443,8 +443,10 @@ class RotorAPI(NodeAPI[Rotor, RotorWrite, RotorList, RotorWriteList]):
                     connection_type=None,
                     connection_property=ViewPropertyId(self._view_id, "wind_turbine"),
                     has_container_fields=True,
+                    include_properties=retrieve_connections == "full",
                 )
             )
+        if retrieve_connections == "full":
             builder.extend(
                 factory.from_direct_relation(
                     SensorTimeSeries._view_id,

--- a/tests/test_integration/test_list.py
+++ b/tests/test_integration/test_list.py
@@ -200,6 +200,16 @@ def test_list_with_reversed_direct_relation_of_list(omni_client: OmniClient) -> 
     assert isinstance(df, pd.DataFrame)
 
 
+def test_list_with_reversed_direct_relations_identifier(omni_client: OmniClient) -> None:
+    items = omni_client.connection_item_e.list(limit=5, retrieve_connections="identifier")
+
+    assert len(items) > 0
+    reverse_direct_relations = [item.direct_reverse_single for item in items if item.direct_reverse_single]
+    assert reverse_direct_relations, f"Missing reverse_direct_single: {reverse_direct_relations}"
+    df = items.to_pandas()
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_list_filter_on_enum(turbine_client: WindTurbineClient) -> None:
     items = turbine_client.sensor_time_series.list(type_="numeric", limit=5)
 


### PR DESCRIPTION
# Description

**Reviewer**: All code inside `examples/` is generated.

See below

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- When calling `.list/.iterate/.retrieve` in the generated SDK with `retrieve_connections="identifier"`, connections modeled as reverse direct relations now also includes the identifiers. 
