### PR TITLE
👷Exclude toolkit

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,10 @@
       "enabled": false,
       "matchManagers": ["poetry"],
       "matchPackagePatterns": ["*"]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": ["cognite-toolkit"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
# Description

Renovate is unsuited for updating cognite-toolkit as this also requires updating the Toolkit modules (configuration files used for tests data). 

## Bump

- [ ] Patch
- [ ] Minor
- [x] Skip
