### PR TITLE
fix: add default value for non-nullable field with default value that needs alias

### DIFF
--- a/cdf/modules/models/omni/data_models/omni/containers/PrimitiveWithDefaults.container.yaml
+++ b/cdf/modules/models/omni/data_models/omni/containers/PrimitiveWithDefaults.container.yaml
@@ -13,6 +13,16 @@ properties:
     autoIncrement: false
     immutable: false
     name: defaultString
+  defaultStringNonNullable:
+    type:
+      list: false
+      collation: ucs_basic
+      type: text
+    nullable: false
+    defaultValue: 'my default text'
+    autoIncrement: false
+    immutable: false
+    name: defaultString
   defaultBoolean:
     type:
       list: false

--- a/cdf/modules/models/omni/data_models/omni/views/PrimitiveWithDefaults.view.yaml
+++ b/cdf/modules/models/omni/data_models/omni/views/PrimitiveWithDefaults.view.yaml
@@ -10,6 +10,13 @@ properties:
       type: container
     containerPropertyIdentifier: defaultString
     name: defaultString
+  defaultStringNonNullable:
+    container:
+      space: {{ pygen_models_space }}
+      externalId: PrimitiveWithDefaults
+      type: container
+    containerPropertyIdentifier: defaultStringNonNullable
+    name: defaultStringNonNullable
   defaultBoolean:
     container:
       space: {{ pygen_models_space }}

--- a/cognite/pygen/_core/models/fields/primitive.py
+++ b/cognite/pygen/_core/models/fields/primitive.py
@@ -161,6 +161,8 @@ class PrimitiveField(BasePrimitiveField):
                 f"Optional[{self.type_as_string}] = "
                 f'{self.pydantic_field}({self.default_code}, alias="{self.prop_name}")'
             )
+        elif not self.is_nullable and self.need_alias and self.default is not None:
+            out_type = f'{self.type_as_string} = {self.pydantic_field}({self.default_code}, alias="{self.prop_name}")'
         elif self.need_alias:
             out_type = f'{self.type_as_string} = {self.pydantic_field}(alias="{self.prop_name}")'
         elif self.is_nullable:

--- a/examples/cognite_core/data_classes/_cognite_time_series.py
+++ b/examples/cognite_core/data_classes/_cognite_time_series.py
@@ -341,7 +341,7 @@ class CogniteTimeSeriesWrite(CogniteDescribableNodeWrite, CogniteSourceableNodeW
     node_type: Union[dm.DirectRelationReference, dm.NodeId, tuple[str, str], None] = None
     assets: Optional[list[Union[CogniteAssetWrite, str, dm.NodeId]]] = Field(default=None, repr=False)
     equipment: Optional[list[Union[CogniteEquipmentWrite, str, dm.NodeId]]] = Field(default=None, repr=False)
-    is_step: bool = Field(alias="isStep")
+    is_step: bool = Field(False, alias="isStep")
     source_unit: Optional[str] = Field(None, alias="sourceUnit")
     type_: Literal["numeric", "string"] = Field(alias="type")
     unit: Union[CogniteUnitWrite, str, dm.NodeId, None] = Field(default=None, repr=False)

--- a/examples/omni/_api/primitive_with_defaults.py
+++ b/examples/omni/_api/primitive_with_defaults.py
@@ -113,6 +113,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -133,6 +135,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32: The maximum value of the default float 32 to filter on.
             default_string: The default string to filter on.
             default_string_prefix: The prefix of the default string to filter on.
+            default_string_non_nullable: The default string non nullable to filter on.
+            default_string_non_nullable_prefix: The prefix of the default string non nullable to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of primitive with defaults to return. Defaults to 25.
@@ -168,6 +172,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32,
             default_string,
             default_string_prefix,
+            default_string_non_nullable,
+            default_string_non_nullable_prefix,
             external_id_prefix,
             space,
             filter,
@@ -199,6 +205,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -222,6 +230,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -249,6 +259,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -275,6 +287,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -299,6 +313,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32: The maximum value of the default float 32 to filter on.
             default_string: The default string to filter on.
             default_string_prefix: The prefix of the default string to filter on.
+            default_string_non_nullable: The default string non nullable to filter on.
+            default_string_non_nullable_prefix: The prefix of the default string non nullable to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of primitive with defaults to return. Defaults to 25.
@@ -328,6 +344,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32,
             default_string,
             default_string_prefix,
+            default_string_non_nullable,
+            default_string_non_nullable_prefix,
             external_id_prefix,
             space,
             filter,
@@ -357,6 +375,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -376,6 +396,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32: The maximum value of the default float 32 to filter on.
             default_string: The default string to filter on.
             default_string_prefix: The prefix of the default string to filter on.
+            default_string_non_nullable: The default string non nullable to filter on.
+            default_string_non_nullable_prefix: The prefix of the default string non nullable to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of primitive with defaults to return.
@@ -396,6 +418,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32,
             default_string,
             default_string_prefix,
+            default_string_non_nullable,
+            default_string_non_nullable_prefix,
             external_id_prefix,
             space,
             filter,
@@ -444,6 +468,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         filter: dm.Filter | None = None,
@@ -461,6 +487,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32: The maximum value of the default float 32 to filter on.
             default_string: The default string to filter on.
             default_string_prefix: The prefix of the default string to filter on.
+            default_string_non_nullable: The default string non nullable to filter on.
+            default_string_non_nullable_prefix: The prefix of the default string non nullable to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             filter: (Advanced) If the filtering available in the above is not sufficient,
@@ -522,6 +550,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32,
             default_string,
             default_string_prefix,
+            default_string_non_nullable,
+            default_string_non_nullable_prefix,
             external_id_prefix,
             space,
             filter,
@@ -537,6 +567,8 @@ class PrimitiveWithDefaultsAPI(
         max_default_float_32: float | None = None,
         default_string: str | list[str] | None = None,
         default_string_prefix: str | None = None,
+        default_string_non_nullable: str | list[str] | None = None,
+        default_string_non_nullable_prefix: str | None = None,
         external_id_prefix: str | None = None,
         space: str | list[str] | None = None,
         limit: int = DEFAULT_LIMIT_READ,
@@ -555,6 +587,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32: The maximum value of the default float 32 to filter on.
             default_string: The default string to filter on.
             default_string_prefix: The prefix of the default string to filter on.
+            default_string_non_nullable: The default string non nullable to filter on.
+            default_string_non_nullable_prefix: The prefix of the default string non nullable to filter on.
             external_id_prefix: The prefix of the external ID to filter on.
             space: The space to filter on.
             limit: Maximum number of primitive with defaults to return.
@@ -588,6 +622,8 @@ class PrimitiveWithDefaultsAPI(
             max_default_float_32,
             default_string,
             default_string_prefix,
+            default_string_non_nullable,
+            default_string_non_nullable_prefix,
             external_id_prefix,
             space,
             filter,

--- a/examples/omni/data_classes/_primitive_with_defaults.py
+++ b/examples/omni/data_classes/_primitive_with_defaults.py
@@ -49,9 +49,15 @@ __all__ = [
 ]
 
 
-PrimitiveWithDefaultsTextFields = Literal["external_id", "default_string"]
+PrimitiveWithDefaultsTextFields = Literal["external_id", "default_string", "default_string_non_nullable"]
 PrimitiveWithDefaultsFields = Literal[
-    "external_id", "auto_increment_int_32", "default_boolean", "default_float_32", "default_object", "default_string"
+    "external_id",
+    "auto_increment_int_32",
+    "default_boolean",
+    "default_float_32",
+    "default_object",
+    "default_string",
+    "default_string_non_nullable",
 ]
 
 _PRIMITIVEWITHDEFAULTS_PROPERTIES_BY_FIELD = {
@@ -61,6 +67,7 @@ _PRIMITIVEWITHDEFAULTS_PROPERTIES_BY_FIELD = {
     "default_float_32": "defaultFloat32",
     "default_object": "defaultObject",
     "default_string": "defaultString",
+    "default_string_non_nullable": "defaultStringNonNullable",
 }
 
 
@@ -79,6 +86,7 @@ class PrimitiveWithDefaultsGraphQL(GraphQLCore):
         default_float_32: The default float 32 field.
         default_object: The default object field.
         default_string: The default string field.
+        default_string_non_nullable: The default string non nullable field.
     """
 
     view_id: ClassVar[dm.ViewId] = dm.ViewId("sp_pygen_models", "PrimitiveWithDefaults", "1")
@@ -87,6 +95,7 @@ class PrimitiveWithDefaultsGraphQL(GraphQLCore):
     default_float_32: Optional[float] = Field(None, alias="defaultFloat32")
     default_object: Optional[dict] = Field(None, alias="defaultObject")
     default_string: Optional[str] = Field(None, alias="defaultString")
+    default_string_non_nullable: Optional[str] = Field(None, alias="defaultStringNonNullable")
 
     @model_validator(mode="before")
     def parse_data_record(cls, values: Any) -> Any:
@@ -122,6 +131,7 @@ class PrimitiveWithDefaults(DomainModel):
         default_float_32: The default float 32 field.
         default_object: The default object field.
         default_string: The default string field.
+        default_string_non_nullable: The default string non nullable field.
     """
 
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("sp_pygen_models", "PrimitiveWithDefaults", "1")
@@ -133,6 +143,7 @@ class PrimitiveWithDefaults(DomainModel):
     default_float_32: Optional[float] = Field(None, alias="defaultFloat32")
     default_object: Optional[dict] = Field(None, alias="defaultObject")
     default_string: Optional[str] = Field(None, alias="defaultString")
+    default_string_non_nullable: str = Field(alias="defaultStringNonNullable")
 
     def as_write(self) -> PrimitiveWithDefaultsWrite:
         """Convert this read version of primitive with default to the writing version."""
@@ -153,6 +164,7 @@ class PrimitiveWithDefaultsWrite(DomainModelWrite):
         default_float_32: The default float 32 field.
         default_object: The default object field.
         default_string: The default string field.
+        default_string_non_nullable: The default string non nullable field.
     """
 
     _container_fields: ClassVar[tuple[str, ...]] = (
@@ -161,6 +173,7 @@ class PrimitiveWithDefaultsWrite(DomainModelWrite):
         "default_float_32",
         "default_object",
         "default_string",
+        "default_string_non_nullable",
     )
 
     _view_id: ClassVar[dm.ViewId] = dm.ViewId("sp_pygen_models", "PrimitiveWithDefaults", "1")
@@ -172,6 +185,7 @@ class PrimitiveWithDefaultsWrite(DomainModelWrite):
     default_float_32: Optional[float] = Field(0.42, alias="defaultFloat32")
     default_object: Optional[dict] = Field({"foo": "bar"}, alias="defaultObject")
     default_string: Optional[str] = Field("my default text", alias="defaultString")
+    default_string_non_nullable: str = Field("my default text", alias="defaultStringNonNullable")
 
 
 class PrimitiveWithDefaultsList(DomainModelList[PrimitiveWithDefaults]):
@@ -199,6 +213,8 @@ def _create_primitive_with_default_filter(
     max_default_float_32: float | None = None,
     default_string: str | list[str] | None = None,
     default_string_prefix: str | None = None,
+    default_string_non_nullable: str | list[str] | None = None,
+    default_string_non_nullable_prefix: str | None = None,
     external_id_prefix: str | None = None,
     space: str | list[str] | None = None,
     filter: dm.Filter | None = None,
@@ -226,6 +242,20 @@ def _create_primitive_with_default_filter(
         filters.append(dm.filters.In(view_id.as_property_ref("defaultString"), values=default_string))
     if default_string_prefix is not None:
         filters.append(dm.filters.Prefix(view_id.as_property_ref("defaultString"), value=default_string_prefix))
+    if isinstance(default_string_non_nullable, str):
+        filters.append(
+            dm.filters.Equals(view_id.as_property_ref("defaultStringNonNullable"), value=default_string_non_nullable)
+        )
+    if default_string_non_nullable and isinstance(default_string_non_nullable, list):
+        filters.append(
+            dm.filters.In(view_id.as_property_ref("defaultStringNonNullable"), values=default_string_non_nullable)
+        )
+    if default_string_non_nullable_prefix is not None:
+        filters.append(
+            dm.filters.Prefix(
+                view_id.as_property_ref("defaultStringNonNullable"), value=default_string_non_nullable_prefix
+            )
+        )
     if external_id_prefix is not None:
         filters.append(dm.filters.Prefix(["node", "externalId"], value=external_id_prefix))
     if isinstance(space, str):
@@ -274,6 +304,7 @@ class _PrimitiveWithDefaultsQuery(NodeQueryCore[T_DomainModelList, PrimitiveWith
         self.default_boolean = BooleanFilter(self, self._view_id.as_property_ref("defaultBoolean"))
         self.default_float_32 = FloatFilter(self, self._view_id.as_property_ref("defaultFloat32"))
         self.default_string = StringFilter(self, self._view_id.as_property_ref("defaultString"))
+        self.default_string_non_nullable = StringFilter(self, self._view_id.as_property_ref("defaultStringNonNullable"))
         self._filter_classes.extend(
             [
                 self.space,
@@ -282,6 +313,7 @@ class _PrimitiveWithDefaultsQuery(NodeQueryCore[T_DomainModelList, PrimitiveWith
                 self.default_boolean,
                 self.default_float_32,
                 self.default_string,
+                self.default_string_non_nullable,
             ]
         )
 

--- a/examples/wind_turbine/data_classes/_sensor_time_series.py
+++ b/examples/wind_turbine/data_classes/_sensor_time_series.py
@@ -192,7 +192,7 @@ class SensorTimeSeriesWrite(DomainModelWrite):
     aliases: Optional[list[str]] = None
     concept_id: Optional[str] = Field(None, alias="conceptId")
     description: Optional[str] = None
-    is_step: bool = Field(alias="isStep")
+    is_step: bool = Field(False, alias="isStep")
     name: Optional[str] = None
     source_unit: Optional[str] = Field(None, alias="sourceUnit")
     standard_name: Optional[str] = Field(None, alias="standardName")

--- a/tests/data/models/Omni/model.yaml
+++ b/tests/data/models/Omni/model.yaml
@@ -1940,6 +1940,22 @@ views:
       defaultValue: my default text
       name: defaultString
       description: null
+    defaultStringNonNullable:
+      container:
+        space: sp_pygen_models
+        externalId: PrimitiveWithDefaults
+      containerPropertyIdentifier: defaultStringNonNullable
+      type:
+        list: false
+        collation: ucs_basic
+        type: text
+      nullable: false
+      immutable: false
+      autoIncrement: false
+      source: null
+      defaultValue: my default text
+      name: defaultString
+      description: null
   lastUpdatedTime: 1729345477397
   createdTime: 1729345477397
 - space: sp_pygen_models

--- a/tests/data/models/Omni/nodes.yaml
+++ b/tests/data/models/Omni/nodes.yaml
@@ -1592,6 +1592,7 @@
           Republican go nor view participant both live.: Another mean own eye organization.
         defaultBoolean: true
         defaultFloat32: -152.55
+        defaultStringNonNullable: Old account which.
         autoIncrementInt32: -734336551
 - space: sp_omni_instances
   externalId: PrimitiveWithDefaults:Austin
@@ -1604,6 +1605,7 @@
       PrimitiveWithDefaults/1:
         defaultObject: {}
         defaultString: Remember measure reduce no employee personal improve.
+        defaultStringNonNullable: Remember measure reduce no employee personal improve.
         defaultFloat32: 8.53
         autoIncrementInt32: -1042816311
 - space: sp_omni_instances
@@ -1623,6 +1625,7 @@
           Represent sea notice back modern officer American.: Yes approach red trip
             area.
         defaultString: Whole arm citizen.
+        defaultStringNonNullable: Whole arm citizen.
         defaultBoolean: false
         autoIncrementInt32: 811875011
 - space: sp_omni_instances
@@ -1638,6 +1641,7 @@
           Raise Congress media voice.: School television smile doctor along.
           Paper win exactly anyone start.: Capital feeling our.
         defaultString: Little body few she two analysis at.
+        defaultStringNonNullable: Little body few she two analysis at.
         defaultBoolean: true
         defaultFloat32: 133.56
         autoIncrementInt32: 42539926
@@ -1651,6 +1655,7 @@
     sp_pygen_models:
       PrimitiveWithDefaults/1:
         defaultString: Southern heart college music better lose.
+        defaultStringNonNullable: Southern heart college music better lose.
         defaultBoolean: false
         defaultFloat32: -186.44
         autoIncrementInt32: 994860070


### PR DESCRIPTION
# Description

**Reviewer**: All code inside `examples/` is generated.

Non-nullable fields with default value that needed an alias would not have the default value set in the generated SDK. This is now fixed.

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Default value is now set in the generated data classes for non-nullable fields that needs an alias.
