### PR TITLE
fix: lower typing-extensions bound to >=4.11.0 for pyodide compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
 
@@ -146,7 +146,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
   validate-description:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"typeguard<4.4.3\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
 
@@ -146,7 +146,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"authlib<1.7.0\", \"typeguard<4.4.3\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
   validate-description:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"typing-extensions>=4.14.0\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
 
@@ -146,7 +146,7 @@ jobs:
           whl_file=$(find dist -name "*.whl" | sed 's|^dist/||') # Find the built wheel file, remove dist/ prefix
           echo "Found built wheel file: $whl_file"
           PYGEN_FILE_PATH=$whl_file \
-          PACKAGES="[\"pyodide-http\", \"pandas\", \"typing-extensions>=4.14.0\", \"http://localhost:3000/dist/$whl_file\"]" \
+          PACKAGES="[\"pyodide-http\", \"pandas\", \"http://localhost:3000/dist/$whl_file\"]" \
           node test-pyodide.js
 
   validate-description:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
     "pydantic>=2.7",
     "Jinja2>=3.1",
     "inflect>=6.2",
-    "typing-extensions>=4.14.0",
+    # pyodide 0.26.2 bundles typing-extensions==4.11.0. Pygen only uses `Self` from typing_extensions
+    # (available since 4.0.0), so 4.11.0 is sufficient. Keeping this at >=4.14.0 causes micropip
+    # in pyodide to try to upgrade typing-extensions (which fails since pyodide packages are locked).
+    "typing-extensions>=4.11.0",
 ]
 
 [project.urls]

--- a/test-pyodide.js
+++ b/test-pyodide.js
@@ -51,5 +51,9 @@ server.listen(PORT, () => {
   test_cognite_sdk().then((result) => {
     console.log("Response from Python =", result);
     server.close();
+  }).catch((err) => {
+    console.error("Error installing or importing pygen:", err);
+    server.close();
+    process.exit(1);
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -543,7 +543,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7" },
     { name = "toml", marker = "extra == 'cli'", specifier = ">=0.10" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.9" },
-    { name = "typing-extensions", specifier = ">=4.14.0" },
+    { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
 provides-extras = ["cli", "format"]
 


### PR DESCRIPTION
## Description

Fixes the pre-existing `build_and_test_jupyter_pyodide` and `build_and_test_streamlit_pyodide` failures that have been breaking all PRs since approximately April 21, 2026 (confirmed by PR #637 failing on that date despite only changing a GH Actions action version).

### Root cause

Pyodide 0.26.2 bundles `typing-extensions==4.11.0` as a locked package that micropip cannot upgrade. The previous lower bound `typing-extensions>=4.14.0` caused micropip to attempt an upgrade — which fails silently but crashes the Node.js process with exit code 1.

The reason this interacted with pydantic: with `pydantic>=2.7` as a constraint, micropip would use pyodide's already-bundled `pydantic==2.7.0` (satisfying the constraint without upgrading). But with `typing-extensions>=4.14.0`, micropip could _not_ use the bundled 4.11.0 and was forced to attempt a fetch/upgrade from PyPI — something pyodide's micropip 0.6.0 cannot reliably do for pre-installed packages.

### Fix

- Lower `typing-extensions` to `>=4.11.0` in `pyproject.toml` (matching pyodide 0.26.2's bundled version)
- Remove the explicit `typing-extensions>=4.14.0` from the pyodide test PACKAGES list in `build.yml`

**Why `>=4.11.0` is sufficient:**
- Pygen itself only imports `Self` from `typing_extensions` (available since 4.0.0)
- `cognite-sdk 8.0.5` only requires `typing_extensions (>=4)`
- `pydantic 2.7.0` (pyodide-bundled) only requires `typing-extensions>=4.6.1`
- Nothing in the import chain uses any 4.14.0+ features at runtime

## Bump

- [x] Patch
- [ ] Minor
- [ ] Skip

## Changelog
### Fixed

- Fixed `build_and_test_jupyter_pyodide` and `build_and_test_streamlit_pyodide` CI failures caused by micropip being unable to upgrade pre-installed `typing-extensions` in pyodide 0.26.2. The `typing-extensions` lower bound is lowered from `>=4.14.0` to `>=4.11.0` (the version bundled with pyodide 0.26.2).